### PR TITLE
fix: stop propagation on track action buttons

### DIFF
--- a/ui/lib/TrackList.svelte
+++ b/ui/lib/TrackList.svelte
@@ -238,20 +238,20 @@
         {:else}
           {#if isReady(track)}
             {#if track.export_path}
-              <button class="open-btn" onclick={() => openFolder(track.export_path)} title={track.export_path}>
+              <button class="open-btn" onclick={(e) => { e.stopPropagation(); openFolder(track.export_path) }} title={track.export_path}>
                 Open folder
               </button>
             {/if}
-            <button class="export-btn" onclick={() => exportStems(track)} disabled={exportingId === track.id}>
+            <button class="export-btn" onclick={(e) => { e.stopPropagation(); exportStems(track) }} disabled={exportingId === track.id}>
               {exportingId === track.id ? 'Exporting…' : '↓ Export stems'}
             </button>
           {/if}
           {#if hasError(track, progress)}
-            <button class="retry-btn" onclick={() => retryTrack(track)} disabled={retryingId === track.id}>
+            <button class="retry-btn" onclick={(e) => { e.stopPropagation(); retryTrack(track) }} disabled={retryingId === track.id}>
               {retryingId === track.id ? 'Retrying…' : '↺ Retry'}
             </button>
           {/if}
-          <button class="delete-btn" onclick={() => deleteTrack(track)} title="Delete track">✕</button>
+          <button class="delete-btn" onclick={(e) => { e.stopPropagation(); deleteTrack(track) }} title="Delete track">✕</button>
         {/if}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Clicking Open Folder, Export Stems, Retry, or Delete on a ready track row was also triggering the row's `onPlay` handler, navigating to the playback screen
- Added `e.stopPropagation()` to all four action buttons in `TrackList.svelte`, matching the existing pattern used on the title/artist edit spans

## Test plan
- [x] Click "Export Stems" on a ready track — folder picker opens, no navigation to playback
- [x] Click "Open Folder" on a track with an export path — folder opens, no navigation
- [x] Click "Delete" — confirmation dialog appears, no navigation
- [x] Click the track row itself (not a button) — navigates to playback as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)