### PR TITLE
docs: add user guide and update features/scope for playback engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ A cross-platform desktop practice app built with Tauri (Rust backend + Svelte fr
 - Manages a library of tracks with metadata (title, artist)
 - Exports stems + original audio to a user-chosen folder
 - Full playback screen: synchronized 4-stem Web Audio engine, waveform display, per-stem mute/solo/volume
-- Analysis stage is **stubbed out** — marked done immediately, no actual beat/note detection yet (TODO: MVP v2)
+- Analysis stage is **stubbed out** — marked done immediately, no actual beat/note detection yet (TODO: MVP v3)
 
 Primary use case: bass player practice with isolated stems.
 
@@ -97,7 +97,8 @@ just dev        # or: pnpm run tauri dev
 | Phase   | Status | Features |
 |---------|--------|----------|
 | MVP     | Done   | YouTube/local input, stem separation, library, export |
-| MVP v2  | In progress | Playback engine ✓, waveforms ✓, stem mute/solo/volume ✓, beat tracking, bass note display |
+| MVP v2  | Done   | Playback engine, waveforms, stem mute/solo/volume |
+| MVP v3  | Next   | Beat tracking, bass note display |
 | Later   | —      | Chord detection, loop sections |
 
 ## Commit & PR conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ A cross-platform desktop practice app built with Tauri (Rust backend + Svelte fr
 - Separates into stems: bass, drums, vocals, other (Demucs via Poetry)
 - Manages a library of tracks with metadata (title, artist)
 - Exports stems + original audio to a user-chosen folder
+- Full playback screen: synchronized 4-stem Web Audio engine, waveform display, per-stem mute/solo/volume
 - Analysis stage is **stubbed out** — marked done immediately, no actual beat/note detection yet (TODO: MVP v2)
 
 Primary use case: bass player practice with isolated stems.
@@ -42,14 +43,16 @@ Each stage updates the DB and emits a `pipeline` Tauri event `{ track_id, stage,
 | `core/src/lib.rs` | App entry point, AppState, command registration |
 | `core/src/db.rs` | SQLite schema, migrations, all CRUD |
 | `core/src/paths.rs` | Path helpers (track_dir, stems_dir, source_wav, etc.) |
-| `core/src/commands.rs` | Tauri commands: add_track_youtube/local, export_stems, update_track_meta, open_folder |
+| `core/src/commands.rs` | Tauri commands: add_track_youtube/local, export_stems, update_track_meta, open_folder, get_stem_paths |
 | `core/src/pipeline/mod.rs` | Async pipeline orchestrator (download → stems → analysis) |
 | `core/src/pipeline/download.rs` | yt-dlp and ffmpeg subprocess wrappers |
 | `core/src/pipeline/stems.rs` | Demucs subprocess, flattens output into stems/ |
 | `core/src/pipeline/analysis.rs` | Analysis runner (currently unused; project_dir() is reused by stems.rs) |
-| `ui/App.svelte` | Root layout, CSS variables, section structure |
+| `ui/App.svelte` | Two-screen layout (library ↔ playback slide transition), screen/selectedTrack state |
 | `ui/lib/AddTrack.svelte` | YouTube URL input + local file picker |
-| `ui/lib/TrackList.svelte` | Library: filter, sort, inline edit, progress, export, delete |
+| `ui/lib/TrackList.svelte` | Library: filter, sort, inline edit, progress, export, delete; emits onPlay for ready tracks |
+| `ui/lib/Playback.svelte` | Playback screen: Web Audio engine, waveforms, transport, stem mute/solo/volume, export |
+| `ui/lib/playback.helpers.js` | Pure functions: formatTime, hashStr, makeWaveformBars, extractWaveform, applyToggleSolo, computeMuted |
 | `python/analyze.py` | Python analysis script (not called yet) |
 | `python/pyproject.toml` | Poetry project: librosa, numpy, demucs (torch 2.6.0) |
 
@@ -82,15 +85,20 @@ just dev        # or: pnpm run tauri dev
 - `analysis::project_dir()` walks 4 parent levels up from the binary to find `python/` — works in dev, will need revisiting for production packaging
 - Demucs is invoked via `poetry run demucs` with `current_dir` set to the analysis project
 - `list_tracks` returns newest-first (`ORDER BY sort_order DESC`)
-- On startup, `incomplete_tracks()` logs any tracks with unfinished pipeline state (not auto-retried)
+- On startup, `mark_interrupted()` resets any `pending` pipeline stages to `error` so the UI can offer retry
+- Playback screen uses Web Audio API: `AudioBufferSourceNode` per stem, `GainNode` per stem, RAF-driven playhead
+- Audio files are loaded via `convertFileSrc` (Tauri asset protocol) + `fetch` + `decodeAudioData`
+- `applyGains()` reads all `stemState` reactive values *before* any early returns so Svelte `$effect` tracks dependencies even before audio loads
+- Track switching is handled by `$effect(() => { const id = track.id; if (id !== loadedTrackId) loadAudio() })` with a stale-load guard
+- `assetProtocol` in `tauri.conf.json` requires the `protocol-asset` Cargo feature
 
 ## Scope
 
 | Phase   | Status | Features |
 |---------|--------|----------|
 | MVP     | Done   | YouTube/local input, stem separation, library, export |
-| MVP v2  | Next   | Playback engine, beat tracking, bass note display |
-| Later   | —      | Chords, stem mute/solo, loop sections, waveform view |
+| MVP v2  | In progress | Playback engine ✓, waveforms ✓, stem mute/solo/volume ✓, beat tracking, bass note display |
+| Later   | —      | Chord detection, loop sections |
 
 ## Commit & PR conventions
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img width="600" alt="wavesplit screenshot" src="https://github.com/user-attachments/assets/1db258ee-9cfd-4a82-aee4-e63c59664bd6" />
 
-A desktop app for musicians to practice with isolated stems. Give it a YouTube URL or a local audio file - it separates the audio into bass, drums, vocals, and other, and lets you export the stems for use in a DAW or practice session.
+A desktop app for musicians to practice with isolated stems. Give it a YouTube URL or a local audio file — it separates the audio into bass, drums, vocals, and other so you can play along, mute parts, or export them to a DAW.
 
 Built with Tauri (Rust + Svelte).
 
@@ -12,10 +12,74 @@ Built with Tauri (Rust + Svelte).
 
 - Add tracks from a YouTube URL or a local audio file
 - Stem separation via [Demucs](https://github.com/facebookresearch/demucs) (bass, drums, vocals, other)
+- Full playback screen with synchronized 4-stem audio engine
+- Per-stem mute, solo, and volume control
+- Waveform display with clickable seek and real-time playhead
 - Export stems + original audio to any folder
 - Library with search and sort (by newest, oldest, title, or artist)
 - Track metadata editing (title and artist)
-- Real-time progress events during pipeline stages
+- Real-time progress during pipeline stages
+
+---
+
+## How to use
+
+### 1. First launch — download Demucs
+
+Wavesplit uses [Demucs](https://github.com/facebookresearch/demucs) to separate audio into stems. On first launch, click **Download Demucs** and wait for the one-time download to complete (~1 GB).
+
+### 2. Add a track
+
+- **YouTube:** paste a YouTube URL into the input field and press Enter or click **Add**
+- **Local file:** click **Open file** and select an audio file (MP3, WAV, FLAC, etc.)
+
+The track appears in the library immediately. Three pipeline stages run in sequence:
+
+| Stage | What happens |
+|-------|-------------|
+| Download | Fetches the audio and converts it to WAV |
+| Stems | Demucs separates it into bass, drums, vocals, other |
+| Analysis | Finalizes the track |
+
+Progress is shown live in the track row. Stem separation typically takes 1–5 minutes depending on your machine.
+
+### 3. Play a track
+
+Once a track shows **Ready**, click anywhere on its row to open the playback screen.
+
+**Transport controls:**
+
+| Button | Action |
+|--------|--------|
+| ‹ | Jump to start |
+| ‹‹ | Rewind 10 seconds |
+| ▶ / ⏸ | Play / Pause |
+| ›› | Forward 10 seconds |
+| › | Jump to end |
+
+Click anywhere on the waveform to seek to that position.
+
+### 4. Mix the stems
+
+Each stem row has three controls:
+
+- **M** — mute that stem
+- **S** — solo that stem (exclusive: only the soloed stem plays; click again to clear)
+- **Volume slider** — adjust the level independently
+
+### 5. Edit track metadata
+
+In the library, click the track title or artist name to edit it inline. Press Enter or click away to save.
+
+### 6. Export stems
+
+Click **↓ Export stems** on any ready track (in the library or the playback screen) to copy the separated WAV files to a folder of your choice. The exported folder contains:
+
+- `vocals.wav`
+- `drums.wav`
+- `bass.wav`
+- `other.wav`
+- `source.wav` (the original converted audio)
 
 ---
 
@@ -93,11 +157,11 @@ Track data is stored in:
 
 ## Roadmap
 
-| Phase   | Features |
-|---------|----------|
-| MVP     | YouTube/local input, stem separation, library, export |
-| MVP v2  | Playback engine, beat tracking, bass note display |
-| Later   | Chord detection, stem mute/solo, loop sections, waveform view |
+| Phase   | Status | Features |
+|---------|--------|----------|
+| MVP     | Done | YouTube/local input, stem separation, library, export |
+| MVP v2  | In progress | Playback engine ✓, waveforms ✓, stem mute/solo/volume ✓, beat tracking, bass note display |
+| Later   | — | Chord detection, loop sections |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ Track data is stored in:
 | Phase   | Status | Features |
 |---------|--------|----------|
 | MVP     | Done | YouTube/local input, stem separation, library, export |
-| MVP v2  | In progress | Playback engine ✓, waveforms ✓, stem mute/solo/volume ✓, beat tracking, bass note display |
+| MVP v2  | Done | Playback engine, waveforms, stem mute/solo/volume |
+| MVP v3  | Next | Beat tracking, bass note display |
 | Later   | — | Chord detection, loop sections |
 
 ---


### PR DESCRIPTION
## Summary
- Added a **How to use** section to the README covering first launch (Demucs download), adding tracks, playback controls, stem mixing, metadata editing, and export
- Updated the **Features** list to include the playback screen, waveforms, and stem mute/solo/volume
- Updated the **Roadmap** to reflect MVP v2 progress (playback engine shipped)
- Updated **CLAUDE.md** with new source files (`Playback.svelte`, `playback.helpers.js`), key behaviours for the audio engine, and corrected scope table

🤖 Generated with [Claude Code](https://claude.com/claude-code)