### PR TITLE
fix: add explicit torch dependency and relax torchaudio pin

### DIFF
--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -1987,4 +1987,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "92d348e3fe45bc43da44508ceedeb80088b8ba9f1fe86ae189d12c5ef9d02b6c"
+content-hash = "4a48280fb103d57f9d9b14a0e3fd7d4e84e717eeab936d75a38b7d6a2d98ec77"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,7 +10,8 @@ dependencies = [
     "librosa (>=0.11.0,<0.12.0)",
     "numpy (>=2.4.4,<3.0.0)",
     "demucs (>=4.0.1,<5.0.0)",
-    "torchaudio (==2.7.0)"
+    "torch (>=2.7.0,<3.0.0)",
+    "torchaudio (>=2.7.0,<3.0.0)"
 ]
 
 


### PR DESCRIPTION
Closes #53

## Summary
- Add explicit `torch (>=2.7.0,<3.0.0)` to `[tool.poetry.dependencies]` so the version is always pinned directly rather than resolved as a transitive dependency of `torchaudio`
- Relax `torchaudio` from `==2.7.0` to `>=2.7.0,<3.0.0` to allow patch updates

## Test plan
- [x] `poetry install` on a fresh venv resolves without version conflicts
- [x] Demucs stem separation still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)