### PR TITLE
fix: add aria-label to stem volume sliders

### DIFF
--- a/ui/lib/Playback.svelte
+++ b/ui/lib/Playback.svelte
@@ -381,6 +381,7 @@
                 onclick={() => toggleSolo(stem.key)} title="Solo">S</button>
         <input class="vol-slider" type="range" min="0" max="1" step="0.01"
                value={state.volume}
+               aria-label="{stem.label} volume"
                style="accent-color:{stem.color}"
                oninput={(e) => stemState[stem.key] = { ...state, volume: +e.target.value }} />
       </div>


### PR DESCRIPTION
## Summary
- Adds `aria-label="{stem.label} volume"` to each stem volume range input so screen reader users know which stem the slider controls.

Closes #57

## Test plan
- [x] Verify sliders still function normally
- [x] Inspect DOM to confirm aria-label is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)