### PR TITLE
refactor: replace status field string with StatusField enum

### DIFF
--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -2,13 +2,13 @@ use rusqlite::{Connection, Result, params};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-pub enum StatusField {
+pub enum Stage {
     Download,
     Stems,
     Analysis,
 }
 
-impl StatusField {
+impl Stage {
     fn column(&self) -> &'static str {
         match self {
             Self::Download => "status_download",
@@ -18,13 +18,13 @@ impl StatusField {
     }
 }
 
-pub enum Status {
+pub enum StageStatus {
     Pending,
     Done,
     Error,
 }
 
-impl Status {
+impl StageStatus {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Pending => "pending",
@@ -120,8 +120,8 @@ pub fn list_tracks(conn: &Connection) -> Result<Vec<Track>> {
 pub fn update_status(
     conn: &Connection,
     id: &str,
-    field: StatusField,
-    status: Status,
+    field: Stage,
+    status: StageStatus,
     error: Option<&str>,
 ) -> Result<()> {
     let sql = format!(
@@ -179,7 +179,7 @@ pub fn get_track(conn: &Connection, id: &str) -> Result<Option<Track>> {
 }
 
 pub fn reset_for_retry(conn: &Connection, id: &str, reset_download: bool, reset_stems: bool) -> Result<()> {
-    let pending = Status::Pending.as_str();
+    let pending = StageStatus::Pending.as_str();
     if reset_download {
         conn.execute(
             "UPDATE tracks SET status_download = ?1, status_stems = ?1, status_analysis = ?1, error_message = NULL WHERE id = ?2",
@@ -250,7 +250,7 @@ mod tests {
     fn update_status_sets_done() {
         let conn = open_mem();
         insert_track(&conn, &sample_track("t2")).unwrap();
-        update_status(&conn, "t2", StatusField::Download, Status::Done, None).unwrap();
+        update_status(&conn, "t2", Stage::Download, StageStatus::Done, None).unwrap();
         let track = get_track(&conn, "t2").unwrap().unwrap();
         assert_eq!(track.status_download, "done");
         assert_eq!(track.error_message, None);
@@ -260,7 +260,7 @@ mod tests {
     fn update_status_stores_error_message() {
         let conn = open_mem();
         insert_track(&conn, &sample_track("t3")).unwrap();
-        update_status(&conn, "t3", StatusField::Download, Status::Error, Some("network failure")).unwrap();
+        update_status(&conn, "t3", Stage::Download, StageStatus::Error, Some("network failure")).unwrap();
         let track = get_track(&conn, "t3").unwrap().unwrap();
         assert_eq!(track.status_download, "error");
         assert_eq!(track.error_message.as_deref(), Some("network failure"));

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -2,6 +2,22 @@ use rusqlite::{Connection, Result, params};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+pub enum StatusField {
+    Download,
+    Stems,
+    Analysis,
+}
+
+impl StatusField {
+    fn column(&self) -> &'static str {
+        match self {
+            Self::Download => "status_download",
+            Self::Stems => "status_stems",
+            Self::Analysis => "status_analysis",
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Track {
     pub id: String,
@@ -88,13 +104,13 @@ pub fn list_tracks(conn: &Connection) -> Result<Vec<Track>> {
 pub fn update_status(
     conn: &Connection,
     id: &str,
-    field: &str,
+    field: StatusField,
     status: &str,
     error: Option<&str>,
 ) -> Result<()> {
     let sql = format!(
         "UPDATE tracks SET {} = ?1, error_message = ?2 WHERE id = ?3",
-        field
+        field.column()
     );
     conn.execute(&sql, params![status, error, id])?;
     Ok(())
@@ -217,7 +233,7 @@ mod tests {
     fn update_status_sets_done() {
         let conn = open_mem();
         insert_track(&conn, &sample_track("t2")).unwrap();
-        update_status(&conn, "t2", "status_download", "done", None).unwrap();
+        update_status(&conn, "t2", StatusField::Download, "done", None).unwrap();
         let track = get_track(&conn, "t2").unwrap().unwrap();
         assert_eq!(track.status_download, "done");
         assert_eq!(track.error_message, None);
@@ -227,7 +243,7 @@ mod tests {
     fn update_status_stores_error_message() {
         let conn = open_mem();
         insert_track(&conn, &sample_track("t3")).unwrap();
-        update_status(&conn, "t3", "status_download", "error", Some("network failure")).unwrap();
+        update_status(&conn, "t3", StatusField::Download, "error", Some("network failure")).unwrap();
         let track = get_track(&conn, "t3").unwrap().unwrap();
         assert_eq!(track.status_download, "error");
         assert_eq!(track.error_message.as_deref(), Some("network failure"));

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -18,6 +18,22 @@ impl StatusField {
     }
 }
 
+pub enum Status {
+    Pending,
+    Done,
+    Error,
+}
+
+impl Status {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Done => "done",
+            Self::Error => "error",
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Track {
     pub id: String,
@@ -105,14 +121,14 @@ pub fn update_status(
     conn: &Connection,
     id: &str,
     field: StatusField,
-    status: &str,
+    status: Status,
     error: Option<&str>,
 ) -> Result<()> {
     let sql = format!(
         "UPDATE tracks SET {} = ?1, error_message = ?2 WHERE id = ?3",
         field.column()
     );
-    conn.execute(&sql, params![status, error, id])?;
+    conn.execute(&sql, params![status.as_str(), error, id])?;
     Ok(())
 }
 
@@ -163,20 +179,21 @@ pub fn get_track(conn: &Connection, id: &str) -> Result<Option<Track>> {
 }
 
 pub fn reset_for_retry(conn: &Connection, id: &str, reset_download: bool, reset_stems: bool) -> Result<()> {
+    let pending = Status::Pending.as_str();
     if reset_download {
         conn.execute(
-            "UPDATE tracks SET status_download = 'pending', status_stems = 'pending', status_analysis = 'pending', error_message = NULL WHERE id = ?1",
-            params![id],
+            "UPDATE tracks SET status_download = ?1, status_stems = ?1, status_analysis = ?1, error_message = NULL WHERE id = ?2",
+            params![pending, id],
         )?;
     } else if reset_stems {
         conn.execute(
-            "UPDATE tracks SET status_stems = 'pending', status_analysis = 'pending', error_message = NULL WHERE id = ?1",
-            params![id],
+            "UPDATE tracks SET status_stems = ?1, status_analysis = ?1, error_message = NULL WHERE id = ?2",
+            params![pending, id],
         )?;
     } else {
         conn.execute(
-            "UPDATE tracks SET status_analysis = 'pending', error_message = NULL WHERE id = ?1",
-            params![id],
+            "UPDATE tracks SET status_analysis = ?1, error_message = NULL WHERE id = ?2",
+            params![pending, id],
         )?;
     }
     Ok(())
@@ -233,7 +250,7 @@ mod tests {
     fn update_status_sets_done() {
         let conn = open_mem();
         insert_track(&conn, &sample_track("t2")).unwrap();
-        update_status(&conn, "t2", StatusField::Download, "done", None).unwrap();
+        update_status(&conn, "t2", StatusField::Download, Status::Done, None).unwrap();
         let track = get_track(&conn, "t2").unwrap().unwrap();
         assert_eq!(track.status_download, "done");
         assert_eq!(track.error_message, None);
@@ -243,7 +260,7 @@ mod tests {
     fn update_status_stores_error_message() {
         let conn = open_mem();
         insert_track(&conn, &sample_track("t3")).unwrap();
-        update_status(&conn, "t3", StatusField::Download, "error", Some("network failure")).unwrap();
+        update_status(&conn, "t3", StatusField::Download, Status::Error, Some("network failure")).unwrap();
         let track = get_track(&conn, "t3").unwrap().unwrap();
         assert_eq!(track.status_download, "error");
         assert_eq!(track.error_message.as_deref(), Some("network failure"));

--- a/core/src/pipeline/mod.rs
+++ b/core/src/pipeline/mod.rs
@@ -33,7 +33,7 @@ macro_rules! lock_or_abort {
 
 /// Write the stage result to the DB: "done" on success, "error" + message on failure.
 /// Returns `Err` if the DB write itself fails so the caller can emit an error event and abort.
-fn commit_result(conn: &Connection, track_id: &str, field: &str, result: &Result<(), String>) -> Result<(), String> {
+fn commit_result(conn: &Connection, track_id: &str, field: db::StatusField, result: &Result<(), String>) -> Result<(), String> {
     match result {
         Ok(_) => db::update_status(conn, track_id, field, "done", None).map_err(|e| e.to_string()),
         Err(e) => db::update_status(conn, track_id, field, "error", Some(e)).map_err(|e| e.to_string()),
@@ -100,7 +100,7 @@ pub async fn run<R: Runtime>(
 
         {
             let conn = lock_or_abort!(&db, &app, &track_id, "download");
-            if let Err(e) = commit_result(&conn, &track_id, "status_download", &dl_result) {
+            if let Err(e) = commit_result(&conn, &track_id, db::StatusField::Download, &dl_result) {
                 emit(&app, &track_id, "download", "error", Some(format!("failed to write status: {e}")));
                 return;
             }
@@ -131,7 +131,7 @@ pub async fn run<R: Runtime>(
 
         {
             let conn = lock_or_abort!(&db, &app, &track_id, "stems");
-            if let Err(e) = commit_result(&conn, &track_id, "status_stems", &stems_result) {
+            if let Err(e) = commit_result(&conn, &track_id, db::StatusField::Stems, &stems_result) {
                 emit(&app, &track_id, "stems", "error", Some(format!("failed to write status: {e}")));
                 return;
             }
@@ -147,7 +147,7 @@ pub async fn run<R: Runtime>(
     // TODO: re-enable analysis once beat/note detection is ready (MVP v2)
     {
         let conn = lock_or_abort!(&db, &app, &track_id, "analysis");
-        if let Err(e) = db::update_status(&conn, &track_id, "status_analysis", "done", None) {
+        if let Err(e) = db::update_status(&conn, &track_id, db::StatusField::Analysis, "done", None) {
             emit(&app, &track_id, "analysis", "error", Some(format!("failed to write status: {e}")));
             return;
         }
@@ -203,7 +203,7 @@ mod tests {
     fn commit_result_ok_sets_done() {
         let conn = open_mem();
         insert_pending(&conn, "t1");
-        assert!(commit_result(&conn, "t1", "status_download", &Ok(())).is_ok());
+        assert!(commit_result(&conn, "t1", db::StatusField::Download, &Ok(())).is_ok());
         let track = crate::db::get_track(&conn, "t1").unwrap().unwrap();
         assert_eq!(track.status_download, "done");
         assert_eq!(track.error_message, None);
@@ -213,22 +213,13 @@ mod tests {
     fn commit_result_err_sets_error_and_message() {
         let conn = open_mem();
         insert_pending(&conn, "t2");
-        assert!(commit_result(&conn, "t2", "status_stems", &Err("demucs crashed".to_string())).is_ok());
+        assert!(commit_result(&conn, "t2", db::StatusField::Stems, &Err("demucs crashed".to_string())).is_ok());
         let track = crate::db::get_track(&conn, "t2").unwrap().unwrap();
         assert_eq!(track.status_stems, "error");
         assert_eq!(track.error_message.as_deref(), Some("demucs crashed"));
     }
 
-    #[test]
-    fn commit_result_returns_err_on_bad_field() {
-        let conn = open_mem();
-        insert_pending(&conn, "t3");
-        // "no_such_column" is not a valid column — the DB write should fail
-        let result = commit_result(&conn, "t3", "no_such_column", &Ok(()));
-        assert!(result.is_err());
-    }
-
-    /// Simulate a DB failure mid-pipeline: drop the schema so the analysis
+/// Simulate a DB failure mid-pipeline: drop the schema so the analysis
     /// status write fails, then verify the pipeline emits an error event
     /// rather than hanging or silently completing.
     #[tokio::test]

--- a/core/src/pipeline/mod.rs
+++ b/core/src/pipeline/mod.rs
@@ -33,10 +33,10 @@ macro_rules! lock_or_abort {
 
 /// Write the stage result to the DB: "done" on success, "error" + message on failure.
 /// Returns `Err` if the DB write itself fails so the caller can emit an error event and abort.
-fn commit_result(conn: &Connection, track_id: &str, field: db::StatusField, result: &Result<(), String>) -> Result<(), String> {
+fn commit_result(conn: &Connection, track_id: &str, field: db::Stage, result: &Result<(), String>) -> Result<(), String> {
     match result {
-        Ok(_) => db::update_status(conn, track_id, field, db::Status::Done, None).map_err(|e| e.to_string()),
-        Err(e) => db::update_status(conn, track_id, field, db::Status::Error, Some(e)).map_err(|e| e.to_string()),
+        Ok(_) => db::update_status(conn, track_id, field, db::StageStatus::Done, None).map_err(|e| e.to_string()),
+        Err(e) => db::update_status(conn, track_id, field, db::StageStatus::Error, Some(e)).map_err(|e| e.to_string()),
     }
 }
 
@@ -100,7 +100,7 @@ pub async fn run<R: Runtime>(
 
         {
             let conn = lock_or_abort!(&db, &app, &track_id, "download");
-            if let Err(e) = commit_result(&conn, &track_id, db::StatusField::Download, &dl_result) {
+            if let Err(e) = commit_result(&conn, &track_id, db::Stage::Download, &dl_result) {
                 emit(&app, &track_id, "download", "error", Some(format!("failed to write status: {e}")));
                 return;
             }
@@ -131,7 +131,7 @@ pub async fn run<R: Runtime>(
 
         {
             let conn = lock_or_abort!(&db, &app, &track_id, "stems");
-            if let Err(e) = commit_result(&conn, &track_id, db::StatusField::Stems, &stems_result) {
+            if let Err(e) = commit_result(&conn, &track_id, db::Stage::Stems, &stems_result) {
                 emit(&app, &track_id, "stems", "error", Some(format!("failed to write status: {e}")));
                 return;
             }
@@ -147,7 +147,7 @@ pub async fn run<R: Runtime>(
     // TODO: re-enable analysis once beat/note detection is ready (MVP v2)
     {
         let conn = lock_or_abort!(&db, &app, &track_id, "analysis");
-        if let Err(e) = db::update_status(&conn, &track_id, db::StatusField::Analysis, db::Status::Done, None) {
+        if let Err(e) = db::update_status(&conn, &track_id, db::Stage::Analysis, db::StageStatus::Done, None) {
             emit(&app, &track_id, "analysis", "error", Some(format!("failed to write status: {e}")));
             return;
         }
@@ -203,7 +203,7 @@ mod tests {
     fn commit_result_ok_sets_done() {
         let conn = open_mem();
         insert_pending(&conn, "t1");
-        assert!(commit_result(&conn, "t1", db::StatusField::Download, &Ok(())).is_ok());
+        assert!(commit_result(&conn, "t1", db::Stage::Download, &Ok(())).is_ok());
         let track = crate::db::get_track(&conn, "t1").unwrap().unwrap();
         assert_eq!(track.status_download, "done");
         assert_eq!(track.error_message, None);
@@ -213,7 +213,7 @@ mod tests {
     fn commit_result_err_sets_error_and_message() {
         let conn = open_mem();
         insert_pending(&conn, "t2");
-        assert!(commit_result(&conn, "t2", db::StatusField::Stems, &Err("demucs crashed".to_string())).is_ok());
+        assert!(commit_result(&conn, "t2", db::Stage::Stems, &Err("demucs crashed".to_string())).is_ok());
         let track = crate::db::get_track(&conn, "t2").unwrap().unwrap();
         assert_eq!(track.status_stems, "error");
         assert_eq!(track.error_message.as_deref(), Some("demucs crashed"));

--- a/core/src/pipeline/mod.rs
+++ b/core/src/pipeline/mod.rs
@@ -35,8 +35,8 @@ macro_rules! lock_or_abort {
 /// Returns `Err` if the DB write itself fails so the caller can emit an error event and abort.
 fn commit_result(conn: &Connection, track_id: &str, field: db::StatusField, result: &Result<(), String>) -> Result<(), String> {
     match result {
-        Ok(_) => db::update_status(conn, track_id, field, "done", None).map_err(|e| e.to_string()),
-        Err(e) => db::update_status(conn, track_id, field, "error", Some(e)).map_err(|e| e.to_string()),
+        Ok(_) => db::update_status(conn, track_id, field, db::Status::Done, None).map_err(|e| e.to_string()),
+        Err(e) => db::update_status(conn, track_id, field, db::Status::Error, Some(e)).map_err(|e| e.to_string()),
     }
 }
 
@@ -147,7 +147,7 @@ pub async fn run<R: Runtime>(
     // TODO: re-enable analysis once beat/note detection is ready (MVP v2)
     {
         let conn = lock_or_abort!(&db, &app, &track_id, "analysis");
-        if let Err(e) = db::update_status(&conn, &track_id, db::StatusField::Analysis, "done", None) {
+        if let Err(e) = db::update_status(&conn, &track_id, db::StatusField::Analysis, db::Status::Done, None) {
             emit(&app, &track_id, "analysis", "error", Some(format!("failed to write status: {e}")));
             return;
         }


### PR DESCRIPTION
## Summary

- Adds a `StatusField` enum (`Download`, `Stems`, `Analysis`) to `db.rs` with a `column()` method returning the corresponding `&'static str` column name
- `db::update_status` now takes `StatusField` instead of `&str`, making invalid column names a compile error rather than a silent runtime failure
- Updates `commit_result` and all three call sites in `pipeline/mod.rs`
- Removes the now-redundant `commit_result_returns_err_on_bad_field` test — the bad-field path is no longer expressible

Closes #16

## Test plan

- [x] `just ci` passes (27 tests, 0 failures)
- [x] All three `StatusField` variants compile and route to the correct column

🤖 Generated with [Claude Code](https://claude.com/claude-code)