### PR TITLE
add: deduplicate tracks by source URL and file path

### DIFF
--- a/core/src/commands.rs
+++ b/core/src/commands.rs
@@ -63,6 +63,12 @@ fn spawn_pipeline(
 }
 
 #[derive(serde::Serialize)]
+pub struct AddTrackResult {
+    pub id: String,
+    pub duplicate: bool,
+}
+
+#[derive(serde::Serialize)]
 pub struct StemPaths {
     pub vocals: String,
     pub drums: String,
@@ -87,11 +93,18 @@ pub async fn add_track_youtube(
     url: String,
     app: AppHandle,
     state: tauri::State<'_, AppState>,
-) -> Result<String, String> {
+) -> Result<AddTrackResult, String> {
     validate_youtube_url(&url)?;
+    {
+        let conn = state.db.lock().map_err(|_| "database unavailable".to_string())?;
+        if let Some(existing) = db::find_by_url(&conn, &url).map_err(|e| e.to_string())? {
+            return Ok(AddTrackResult { id: existing.id, duplicate: true });
+        }
+    }
     let title = pipeline::download::youtube_title(&url)
         .unwrap_or_else(|| url.clone());
-    add_track(Source::Youtube(url.clone()), title, Some(url), None, app, state).await
+    let id = add_track(Source::Youtube(url.clone()), title, Some(url), None, app, state).await?;
+    Ok(AddTrackResult { id, duplicate: false })
 }
 
 #[tauri::command]
@@ -99,10 +112,17 @@ pub async fn add_track_local(
     path: String,
     app: AppHandle,
     state: tauri::State<'_, AppState>,
-) -> Result<String, String> {
+) -> Result<AddTrackResult, String> {
+    {
+        let conn = state.db.lock().map_err(|_| "database unavailable".to_string())?;
+        if let Some(existing) = db::find_by_path(&conn, &path).map_err(|e| e.to_string())? {
+            return Ok(AddTrackResult { id: existing.id, duplicate: true });
+        }
+    }
     let src = std::path::PathBuf::from(&path);
     let title = pipeline::download::local_title(&src);
-    add_track(Source::Local(src), title, None, Some(path), app, state).await
+    let id = add_track(Source::Local(src), title, None, Some(path), app, state).await?;
+    Ok(AddTrackResult { id, duplicate: false })
 }
 
 async fn add_track(

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -119,6 +119,60 @@ pub fn mark_interrupted(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+pub fn find_by_url(conn: &Connection, url: &str) -> Result<Option<Track>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, title, source_type, source_url, source_path, created_at, sort_order, duration_ms,
+                status_download, status_stems, status_analysis, error_message, export_path, artist
+         FROM tracks WHERE source_url = ?1",
+    )?;
+    let mut rows = stmt.query_map(params![url], |row| {
+        Ok(Track {
+            id: row.get(0)?,
+            title: row.get(1)?,
+            source_type: row.get(2)?,
+            source_url: row.get(3)?,
+            source_path: row.get(4)?,
+            created_at: row.get(5)?,
+            sort_order: row.get(6)?,
+            duration_ms: row.get(7)?,
+            status_download: row.get(8)?,
+            status_stems: row.get(9)?,
+            status_analysis: row.get(10)?,
+            error_message: row.get(11)?,
+            export_path: row.get(12)?,
+            artist: row.get(13)?,
+        })
+    })?;
+    rows.next().transpose()
+}
+
+pub fn find_by_path(conn: &Connection, path: &str) -> Result<Option<Track>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, title, source_type, source_url, source_path, created_at, sort_order, duration_ms,
+                status_download, status_stems, status_analysis, error_message, export_path, artist
+         FROM tracks WHERE source_path = ?1",
+    )?;
+    let mut rows = stmt.query_map(params![path], |row| {
+        Ok(Track {
+            id: row.get(0)?,
+            title: row.get(1)?,
+            source_type: row.get(2)?,
+            source_url: row.get(3)?,
+            source_path: row.get(4)?,
+            created_at: row.get(5)?,
+            sort_order: row.get(6)?,
+            duration_ms: row.get(7)?,
+            status_download: row.get(8)?,
+            status_stems: row.get(9)?,
+            status_analysis: row.get(10)?,
+            error_message: row.get(11)?,
+            export_path: row.get(12)?,
+            artist: row.get(13)?,
+        })
+    })?;
+    rows.next().transpose()
+}
+
 pub fn get_track(conn: &Connection, id: &str) -> Result<Option<Track>> {
     let mut stmt = conn.prepare(
         "SELECT id, title, source_type, source_url, source_path, created_at, sort_order, duration_ms,
@@ -320,6 +374,40 @@ mod tests {
         set_export_path(&conn, "t11", "/exports/t11").unwrap();
         let track = get_track(&conn, "t11").unwrap().unwrap();
         assert_eq!(track.export_path.as_deref(), Some("/exports/t11"));
+    }
+
+    #[test]
+    fn find_by_url_returns_existing_track() {
+        let conn = open_mem();
+        insert_track(&conn, &sample_track("t13")).unwrap();
+        let found = find_by_url(&conn, "https://example.com").unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, "t13");
+    }
+
+    #[test]
+    fn find_by_url_returns_none_for_unknown_url() {
+        let conn = open_mem();
+        assert!(find_by_url(&conn, "https://other.com").unwrap().is_none());
+    }
+
+    #[test]
+    fn find_by_path_returns_existing_track() {
+        let conn = open_mem();
+        let mut track = sample_track("t14");
+        track.source_type = "local".to_string();
+        track.source_url = None;
+        track.source_path = Some("/music/song.mp3".to_string());
+        insert_track(&conn, &track).unwrap();
+        let found = find_by_path(&conn, "/music/song.mp3").unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, "t14");
+    }
+
+    #[test]
+    fn find_by_path_returns_none_for_unknown_path() {
+        let conn = open_mem();
+        assert!(find_by_path(&conn, "/music/missing.mp3").unwrap().is_none());
     }
 
     #[test]

--- a/ui/lib/AddTrack.svelte
+++ b/ui/lib/AddTrack.svelte
@@ -32,8 +32,9 @@
     url = ''
     onStarted(pendingUrl)
     try {
-      const id = await invoke('add_track_youtube', { url: pendingUrl })
-      onAdded(id)
+      const result = await invoke('add_track_youtube', { url: pendingUrl })
+      if (result.duplicate) error = 'This track is already in your library'
+      onAdded(result.id)
     } catch (e) {
       error = String(e)
       onAdded(null)
@@ -53,8 +54,9 @@
     // Normalize backslashes for Windows paths (display only — `selected` is passed as-is to the backend)
     onStarted(selected.replace(/\\/g, '/').split('/').pop() ?? 'Local file')
     try {
-      const id = await invoke('add_track_local', { path: selected })
-      onAdded(id)
+      const result = await invoke('add_track_local', { path: selected })
+      if (result.duplicate) error = 'This track is already in your library'
+      onAdded(result.id)
     } catch (e) {
       error = String(e)
       onAdded(null)


### PR DESCRIPTION
## Summary

- Submitting the same YouTube URL or local file path twice no longer creates a duplicate row, download, or Demucs run
- Added `db::find_by_url` and `db::find_by_path` — checked before insert in `add_track_youtube`/`add_track_local`, before any network work
- Commands now return `AddTrackResult { id, duplicate }` instead of a bare string; the frontend surfaces "This track is already in your library" when `duplicate` is true while still refreshing the list with the existing track's ID

## Test plan

- [x] Submit the same YouTube URL twice — second attempt shows "already in library", no new row in library
- [x] Open the same local file twice — same behaviour
- [x] First submission of a new URL/file still creates and processes the track normally
- [x] 4 new unit tests added for `find_by_url` / `find_by_path` (found + not-found cases)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)