### PR TITLE
fix: keep library header fixed when scrolling tracks

### DIFF
--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -204,7 +204,8 @@
 
   .list-section {
     flex: 1;
-    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
     min-height: 0;
   }
 

--- a/ui/lib/TrackList.svelte
+++ b/ui/lib/TrackList.svelte
@@ -162,6 +162,7 @@
     </div>
   {/if}
 
+  <div class="tracks-scroll">
   {#if editError}
     <p class="export-error">{editError} <button class="dismiss-error" onclick={() => editError = ''}>×</button></p>
   {/if}
@@ -255,19 +256,31 @@
       </div>
     </div>
   {/each}
+  </div>
 </div>
 
 <style>
   .track-list {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    flex: 1;
+    min-height: 0;
   }
 
   .toolbar {
     display: flex;
     gap: 6px;
-    margin-bottom: 6px;
+    margin-bottom: 8px;
+    flex-shrink: 0;
+  }
+
+  .tracks-scroll {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
   }
 
   .filter-input {


### PR DESCRIPTION
## Summary
- The "Library" label and search/sort toolbar were inside the scrollable list container, causing them to disappear when scrolling through tracks
- Moved the scroll container to a `.tracks-scroll` div wrapping only the track rows inside `TrackList`
- Section label and toolbar now stay fixed without any `position: sticky` hacks

## Test plan
- [x] Open the library with several tracks and scroll — "Library" label and search bar should remain visible
- [x] Search filter and sort still work as expected
- [x] Error banners (edit/delete/export/retry) scroll with the tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)