### PR TITLE
fix: keep library header fixed when scrolling tracks

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -40,3 +40,9 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Svelte check
+        run: pnpm check
+
+      - name: Prettier check
+        run: pnpm format:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
             touch core/binaries/${bin}-x86_64-unknown-linux-gnu
           done
 
+      - name: cargo fmt
+        working-directory: core
+        run: cargo fmt --check
+
       - name: cargo clippy
         working-directory: core
         run: cargo clippy --all-targets -- -D warnings

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Claude Code session data
+.claude/
+
 # Editor directories and files
 .vscode
 .idea

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "plugins": ["prettier-plugin-svelte"],
+  "overrides": [
+    {
+      "files": "*.svelte",
+      "options": {
+        "parser": "svelte"
+      }
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,8 +77,30 @@ Migrations are additive via `.ok()` on `ALTER TABLE` in `db::open()`.
 brew install yt-dlp ffmpeg poetry
 cd python && poetry install
 pnpm install
-just dev        # or: pnpm run tauri dev
+just install-hooks  # install pre-commit hook (once per clone)
+just dev            # or: pnpm run tauri dev
 ```
+
+## Linting & CI
+
+Run all checks before pushing:
+
+```sh
+just ci          # fmt-check + clippy + cargo test + vite build + svelte-check + prettier
+just fix         # auto-format Rust + frontend (then re-run ci)
+```
+
+Individual commands:
+- `just fmt-check` / `just fmt` — Rust formatting (check / fix)
+- `just lint` — cargo clippy -D warnings
+- `just test` — cargo test
+- `just check-ui` — svelte-check (Svelte component errors)
+- `just lint-ui` — Prettier formatting check
+- `just build-ui` — Vite build (frontend only)
+
+Frontend config: `.prettierrc` (Prettier), `jsconfig.json` (JS/Svelte type checking, excludes `dist/` and `*.test.js`).
+
+CI runs on every push/PR (`ci.yml` for Rust, `ci-frontend.yml` for frontend). Both workflows mirror `just ci`.
 
 ## Important behaviours
 

--- a/README.md
+++ b/README.md
@@ -126,13 +126,19 @@ just dev
 Other commands:
 
 ```sh
-just build       # Build release binary + installer
-just check       # Check Rust without building
-just test        # Run Rust tests
-just fmt         # Format Rust code
-just lint        # Clippy (warnings as errors)
-just open-data   # Open app data directory (macOS)
-just reset-data  # Wipe all app data and tracks (destructive)
+just build          # Build release binary + installer
+just check          # Check Rust without building
+just test           # Run Rust tests
+just fmt            # Format Rust code
+just fmt-check      # Check Rust formatting without modifying files
+just fix            # Auto-format Rust + frontend
+just lint           # Clippy (warnings as errors)
+just check-ui       # svelte-check (Svelte component type checking)
+just lint-ui        # Prettier formatting check
+just ci             # Run all CI checks locally (fmt + clippy + test + build + svelte-check + prettier)
+just install-hooks  # Install git pre-commit hook (run once after cloning)
+just open-data      # Open app data directory (macOS)
+just reset-data     # Wipe all app data and tracks (destructive)
 ```
 
 ---

--- a/core/src/commands.rs
+++ b/core/src/commands.rs
@@ -1,10 +1,10 @@
+use chrono::Utc;
+use rusqlite::Connection;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use rusqlite::Connection;
 use tauri::AppHandle;
-use uuid::Uuid;
-use chrono::Utc;
 use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
 
 use crate::db::{self, Track};
 use crate::paths;
@@ -25,7 +25,9 @@ fn validate_youtube_url(raw: &str) -> Result<(), String> {
     }
     let host = parsed.host_str().unwrap_or("");
     if !ALLOWED_YOUTUBE_HOSTS.contains(&host) {
-        return Err(format!("URL host '{host}' is not an allowed YouTube domain"));
+        return Err(format!(
+            "URL host '{host}' is not an allowed YouTube domain"
+        ));
     }
     Ok(())
 }
@@ -55,10 +57,26 @@ fn spawn_pipeline(
     start_stage: pipeline::StartStage,
     tasks: Arc<Mutex<HashMap<String, CancellationToken>>>,
 ) {
-    tasks.lock().unwrap_or_else(|e| e.into_inner()).insert(track_id.clone(), token.clone());
+    tasks
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(track_id.clone(), token.clone());
     tokio::spawn(async move {
-        let _guard = TaskGuard { tasks, track_id: track_id.clone() };
-        pipeline::run(track_id, source, db, data_dir, demucs_dir, token, app, start_stage).await;
+        let _guard = TaskGuard {
+            tasks,
+            track_id: track_id.clone(),
+        };
+        pipeline::run(
+            track_id,
+            source,
+            db,
+            data_dir,
+            demucs_dir,
+            token,
+            app,
+            start_stage,
+        )
+        .await;
     });
 }
 
@@ -71,14 +89,17 @@ pub struct StemPaths {
 }
 
 #[tauri::command]
-pub fn get_stem_paths(track_id: String, state: tauri::State<'_, AppState>) -> Result<StemPaths, String> {
+pub fn get_stem_paths(
+    track_id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<StemPaths, String> {
     let stems = paths::stems_dir(&state.data_dir, &track_id);
     let p = |name: &str| stems.join(name).to_string_lossy().into_owned();
     Ok(StemPaths {
         vocals: p("vocals.wav"),
-        drums:  p("drums.wav"),
-        bass:   p("bass.wav"),
-        other:  p("other.wav"),
+        drums: p("drums.wav"),
+        bass: p("bass.wav"),
+        other: p("other.wav"),
     })
 }
 
@@ -89,9 +110,16 @@ pub async fn add_track_youtube(
     state: tauri::State<'_, AppState>,
 ) -> Result<String, String> {
     validate_youtube_url(&url)?;
-    let title = pipeline::download::youtube_title(&url)
-        .unwrap_or_else(|| url.clone());
-    add_track(Source::Youtube(url.clone()), title, Some(url), None, app, state).await
+    let title = pipeline::download::youtube_title(&url).unwrap_or_else(|| url.clone());
+    add_track(
+        Source::Youtube(url.clone()),
+        title,
+        Some(url),
+        None,
+        app,
+        state,
+    )
+    .await
 }
 
 #[tauri::command]
@@ -114,33 +142,45 @@ async fn add_track(
     state: tauri::State<'_, AppState>,
 ) -> Result<String, String> {
     let id = Uuid::new_v4().to_string();
-    let source_type = if source_url.is_some() { "youtube" } else { "local" };
+    let source_type = if source_url.is_some() {
+        "youtube"
+    } else {
+        "local"
+    };
 
     // Create track directories
     std::fs::create_dir_all(paths::track_dir(&state.data_dir, &id)).map_err(|e| e.to_string())?;
     std::fs::create_dir_all(paths::stems_dir(&state.data_dir, &id)).map_err(|e| e.to_string())?;
-    std::fs::create_dir_all(paths::analysis_dir(&state.data_dir, &id)).map_err(|e| e.to_string())?;
+    std::fs::create_dir_all(paths::analysis_dir(&state.data_dir, &id))
+        .map_err(|e| e.to_string())?;
 
     // Insert DB row
     {
-        let conn = state.db.lock().map_err(|_| "database unavailable".to_string())?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|_| "database unavailable".to_string())?;
         let order = db::next_sort_order(&conn).map_err(|e| e.to_string())?;
-        db::insert_track(&conn, &Track {
-            id: id.clone(),
-            title,
-            source_type: source_type.to_string(),
-            source_url,
-            source_path,
-            created_at: Utc::now().to_rfc3339(),
-            sort_order: order,
-            duration_ms: None,
-            status_download: "pending".into(),
-            status_stems: "pending".into(),
-            status_analysis: "pending".into(),
-            error_message: None,
-            export_path: None,
-            artist: None,
-        }).map_err(|e| e.to_string())?;
+        db::insert_track(
+            &conn,
+            &Track {
+                id: id.clone(),
+                title,
+                source_type: source_type.to_string(),
+                source_url,
+                source_path,
+                created_at: Utc::now().to_rfc3339(),
+                sort_order: order,
+                duration_ms: None,
+                status_download: "pending".into(),
+                status_stems: "pending".into(),
+                status_analysis: "pending".into(),
+                error_message: None,
+                export_path: None,
+                artist: None,
+            },
+        )
+        .map_err(|e| e.to_string())?;
     }
 
     // Spawn pipeline in background with a cancellation token.
@@ -161,7 +201,11 @@ async fn add_track(
 }
 
 #[tauri::command]
-pub fn export_stems(track_id: String, dest_dir: String, state: tauri::State<'_, AppState>) -> Result<Vec<String>, String> {
+pub fn export_stems(
+    track_id: String,
+    dest_dir: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<String>, String> {
     let stems_dir = paths::stems_dir(&state.data_dir, &track_id);
     let dest = std::path::PathBuf::from(&dest_dir);
 
@@ -187,7 +231,10 @@ pub fn export_stems(track_id: String, dest_dir: String, state: tauri::State<'_, 
         return Err("No stem files found for this track".into());
     }
 
-    let conn = state.db.lock().map_err(|_| "database unavailable".to_string())?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| "database unavailable".to_string())?;
     db::set_export_path(&conn, &track_id, &dest_dir).map_err(|e| e.to_string())?;
 
     Ok(exported)
@@ -200,7 +247,10 @@ pub fn update_track_meta(
     artist: Option<String>,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
-    let conn = state.db.lock().map_err(|_| "database unavailable".to_string())?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| "database unavailable".to_string())?;
     db::update_track_meta(&conn, &id, &title, artist.as_deref()).map_err(|e| e.to_string())
 }
 
@@ -221,12 +271,20 @@ pub async fn retry_track(
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
     // Don't retry if already running
-    if state.tasks.lock().map_err(|_| "tasks unavailable".to_string())?.contains_key(&id) {
+    if state
+        .tasks
+        .lock()
+        .map_err(|_| "tasks unavailable".to_string())?
+        .contains_key(&id)
+    {
         return Err("track is already processing".to_string());
     }
 
     let track = {
-        let conn = state.db.lock().map_err(|_| "database unavailable".to_string())?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|_| "database unavailable".to_string())?;
         db::get_track(&conn, &id)
             .map_err(|e| e.to_string())?
             .ok_or_else(|| "track not found".to_string())?
@@ -241,17 +299,24 @@ pub async fn retry_track(
     };
 
     {
-        let conn = state.db.lock().map_err(|_| "database unavailable".to_string())?;
+        let conn = state
+            .db
+            .lock()
+            .map_err(|_| "database unavailable".to_string())?;
         db::reset_for_retry(&conn, &id, reset_download, reset_stems).map_err(|e| e.to_string())?;
     }
 
     let source = match track.source_type.as_str() {
         "youtube" => {
-            let url = track.source_url.ok_or_else(|| "missing source URL".to_string())?;
+            let url = track
+                .source_url
+                .ok_or_else(|| "missing source URL".to_string())?;
             pipeline::Source::Youtube(url)
         }
         _ => {
-            let path = track.source_path.ok_or_else(|| "missing source path".to_string())?;
+            let path = track
+                .source_path
+                .ok_or_else(|| "missing source path".to_string())?;
             pipeline::Source::Local(std::path::PathBuf::from(path))
         }
     };
@@ -303,7 +368,10 @@ mod tests {
             ("https://www.youtube.com.evil.com/x", "lookalike domain"),
         ];
         for (url, label) in &invalid {
-            assert!(validate_youtube_url(url).is_err(), "should reject ({label}): {url}");
+            assert!(
+                validate_youtube_url(url).is_err(),
+                "should reject ({label}): {url}"
+            );
         }
     }
 
@@ -319,7 +387,10 @@ mod tests {
         let tasks_clone = Arc::clone(&tasks);
         let tid = track_id.clone();
         let handle = tokio::spawn(async move {
-            let _guard = TaskGuard { tasks: tasks_clone, track_id: tid };
+            let _guard = TaskGuard {
+                tasks: tasks_clone,
+                track_id: tid,
+            };
             panic!("simulated pipeline panic");
         });
         let _ = handle.await; // absorb JoinError

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -1,4 +1,4 @@
-use rusqlite::{Connection, Result, params};
+use rusqlite::{params, Connection, Result};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -25,8 +25,10 @@ pub fn open(db_path: &Path) -> Result<Connection> {
     conn.execute_batch(include_str!("../schema.sql"))?;
     conn.execute_batch("PRAGMA journal_mode=WAL;")?;
     // Migrations — .ok() makes each idempotent (fails silently if column already exists)
-    conn.execute_batch("ALTER TABLE tracks ADD COLUMN export_path TEXT;").ok();
-    conn.execute_batch("ALTER TABLE tracks ADD COLUMN artist TEXT;").ok();
+    conn.execute_batch("ALTER TABLE tracks ADD COLUMN export_path TEXT;")
+        .ok();
+    conn.execute_batch("ALTER TABLE tracks ADD COLUMN artist TEXT;")
+        .ok();
     Ok(conn)
 }
 
@@ -45,11 +47,19 @@ pub fn insert_track(conn: &Connection, track: &Track) -> Result<()> {
 }
 
 pub fn set_export_path(conn: &Connection, id: &str, path: &str) -> Result<()> {
-    conn.execute("UPDATE tracks SET export_path = ?1 WHERE id = ?2", params![path, id])?;
+    conn.execute(
+        "UPDATE tracks SET export_path = ?1 WHERE id = ?2",
+        params![path, id],
+    )?;
     Ok(())
 }
 
-pub fn update_track_meta(conn: &Connection, id: &str, title: &str, artist: Option<&str>) -> Result<()> {
+pub fn update_track_meta(
+    conn: &Connection,
+    id: &str,
+    title: &str,
+    artist: Option<&str>,
+) -> Result<()> {
     conn.execute(
         "UPDATE tracks SET title = ?1, artist = ?2 WHERE id = ?3",
         params![title, artist, id],
@@ -63,25 +73,26 @@ pub fn list_tracks(conn: &Connection) -> Result<Vec<Track>> {
                 status_download, status_stems, status_analysis, error_message, export_path, artist
          FROM tracks ORDER BY sort_order DESC",
     )?;
-    let tracks = stmt.query_map([], |row| {
-        Ok(Track {
-            id: row.get(0)?,
-            title: row.get(1)?,
-            source_type: row.get(2)?,
-            source_url: row.get(3)?,
-            source_path: row.get(4)?,
-            created_at: row.get(5)?,
-            sort_order: row.get(6)?,
-            duration_ms: row.get(7)?,
-            status_download: row.get(8)?,
-            status_stems: row.get(9)?,
-            status_analysis: row.get(10)?,
-            error_message: row.get(11)?,
-            export_path: row.get(12)?,
-            artist: row.get(13)?,
-        })
-    })?
-    .collect::<Result<Vec<_>>>()?;
+    let tracks = stmt
+        .query_map([], |row| {
+            Ok(Track {
+                id: row.get(0)?,
+                title: row.get(1)?,
+                source_type: row.get(2)?,
+                source_url: row.get(3)?,
+                source_path: row.get(4)?,
+                created_at: row.get(5)?,
+                sort_order: row.get(6)?,
+                duration_ms: row.get(7)?,
+                status_download: row.get(8)?,
+                status_stems: row.get(9)?,
+                status_analysis: row.get(10)?,
+                error_message: row.get(11)?,
+                export_path: row.get(12)?,
+                artist: row.get(13)?,
+            })
+        })?
+        .collect::<Result<Vec<_>>>()?;
     Ok(tracks)
 }
 
@@ -146,7 +157,12 @@ pub fn get_track(conn: &Connection, id: &str) -> Result<Option<Track>> {
     rows.next().transpose()
 }
 
-pub fn reset_for_retry(conn: &Connection, id: &str, reset_download: bool, reset_stems: bool) -> Result<()> {
+pub fn reset_for_retry(
+    conn: &Connection,
+    id: &str,
+    reset_download: bool,
+    reset_stems: bool,
+) -> Result<()> {
     if reset_download {
         conn.execute(
             "UPDATE tracks SET status_download = 'pending', status_stems = 'pending', status_analysis = 'pending', error_message = NULL WHERE id = ?1",
@@ -167,11 +183,8 @@ pub fn reset_for_retry(conn: &Connection, id: &str, reset_download: bool, reset_
 }
 
 pub fn next_sort_order(conn: &Connection) -> Result<i64> {
-    let max: Option<i64> = conn.query_row(
-        "SELECT MAX(sort_order) FROM tracks",
-        [],
-        |row| row.get(0),
-    )?;
+    let max: Option<i64> =
+        conn.query_row("SELECT MAX(sort_order) FROM tracks", [], |row| row.get(0))?;
     Ok(max.unwrap_or(0) + 1)
 }
 
@@ -227,7 +240,14 @@ mod tests {
     fn update_status_stores_error_message() {
         let conn = open_mem();
         insert_track(&conn, &sample_track("t3")).unwrap();
-        update_status(&conn, "t3", "status_download", "error", Some("network failure")).unwrap();
+        update_status(
+            &conn,
+            "t3",
+            "status_download",
+            "error",
+            Some("network failure"),
+        )
+        .unwrap();
         let track = get_track(&conn, "t3").unwrap().unwrap();
         assert_eq!(track.status_download, "error");
         assert_eq!(track.error_message.as_deref(), Some("network failure"));

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,9 +4,9 @@ mod paths;
 mod pipeline;
 mod setup;
 
+use rusqlite::Connection;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use rusqlite::Connection;
 use tauri::{AppHandle, Manager};
 use tokio_util::sync::CancellationToken;
 
@@ -22,7 +22,10 @@ pub struct AppState {
 
 #[tauri::command]
 fn list_tracks(state: tauri::State<AppState>) -> Result<Vec<db::Track>, String> {
-    let conn = state.db.lock().map_err(|_| "database unavailable".to_string())?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| "database unavailable".to_string())?;
     db::list_tracks(&conn).map_err(|e| e.to_string())
 }
 
@@ -34,7 +37,10 @@ fn delete_track(id: String, state: tauri::State<AppState>) -> Result<(), String>
             token.cancel();
         }
     }
-    let conn = state.db.lock().map_err(|_| "database unavailable".to_string())?;
+    let conn = state
+        .db
+        .lock()
+        .map_err(|_| "database unavailable".to_string())?;
     db::delete_track(&conn, &id).map_err(|e| e.to_string())?;
     drop(conn);
     let track_dir = paths::track_dir(&state.data_dir, &id);

--- a/core/src/paths.rs
+++ b/core/src/paths.rs
@@ -16,7 +16,6 @@ pub fn source_wav(data_dir: &Path, id: &str) -> PathBuf {
     track_dir(data_dir, id).join("source.wav")
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -25,22 +24,34 @@ mod tests {
 
     #[test]
     fn track_dir_is_data_tracks_id() {
-        assert_eq!(track_dir(Path::new(DATA), "abc"), Path::new("/data/tracks/abc"));
+        assert_eq!(
+            track_dir(Path::new(DATA), "abc"),
+            Path::new("/data/tracks/abc")
+        );
     }
 
     #[test]
     fn stems_dir_is_under_track_dir() {
-        assert_eq!(stems_dir(Path::new(DATA), "abc"), Path::new("/data/tracks/abc/stems"));
+        assert_eq!(
+            stems_dir(Path::new(DATA), "abc"),
+            Path::new("/data/tracks/abc/stems")
+        );
     }
 
     #[test]
     fn analysis_dir_is_under_track_dir() {
-        assert_eq!(analysis_dir(Path::new(DATA), "abc"), Path::new("/data/tracks/abc/analysis"));
+        assert_eq!(
+            analysis_dir(Path::new(DATA), "abc"),
+            Path::new("/data/tracks/abc/analysis")
+        );
     }
 
     #[test]
     fn source_wav_is_in_track_dir() {
-        assert_eq!(source_wav(Path::new(DATA), "abc"), Path::new("/data/tracks/abc/source.wav"));
+        assert_eq!(
+            source_wav(Path::new(DATA), "abc"),
+            Path::new("/data/tracks/abc/source.wav")
+        );
     }
 
     #[test]

--- a/core/src/pipeline/analysis.rs
+++ b/core/src/pipeline/analysis.rs
@@ -9,10 +9,14 @@ pub fn project_dir() -> std::path::PathBuf {
     let exe = std::env::current_exe().unwrap_or_default();
     // dev path: core/target/debug/wavesplit → up 4 levels to repo root, then python/
     let dev_path = exe
-        .parent().unwrap_or(Path::new("."))
-        .parent().unwrap_or(Path::new("."))
-        .parent().unwrap_or(Path::new("."))
-        .parent().unwrap_or(Path::new("."))
+        .parent()
+        .unwrap_or(Path::new("."))
+        .parent()
+        .unwrap_or(Path::new("."))
+        .parent()
+        .unwrap_or(Path::new("."))
+        .parent()
+        .unwrap_or(Path::new("."))
         .join("python");
     if dev_path.join("pyproject.toml").exists() {
         return dev_path;
@@ -34,7 +38,8 @@ pub fn run(stems_dir: &Path, analysis_dir: &Path) -> Result<(), String> {
 
     let status = Command::new("poetry")
         .args([
-            "run", "python3",
+            "run",
+            "python3",
             script.to_str().ok_or("invalid script path")?,
             stems_dir.to_str().ok_or("invalid stems_dir path")?,
             analysis_dir.to_str().ok_or("invalid analysis_dir path")?,

--- a/core/src/pipeline/download.rs
+++ b/core/src/pipeline/download.rs
@@ -6,14 +6,21 @@ use super::bins;
 /// For a YouTube URL: download audio and convert to WAV at `dest`.
 pub fn from_youtube(url: &str, dest: &Path) -> Result<(), String> {
     let ffmpeg = bins::resolve("ffmpeg");
-    let ffmpeg_dir = ffmpeg.parent().map(|p| p.to_path_buf()).unwrap_or(ffmpeg.clone());
+    let ffmpeg_dir = ffmpeg
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or(ffmpeg.clone());
     let output = Command::new(bins::resolve("yt-dlp"))
         .args([
-            "--ffmpeg-location", ffmpeg_dir.to_str().ok_or("invalid ffmpeg path")?,
+            "--ffmpeg-location",
+            ffmpeg_dir.to_str().ok_or("invalid ffmpeg path")?,
             "-x",
-            "--audio-format", "wav",
-            "--audio-quality", "0",
-            "-o", dest.to_str().ok_or("invalid dest path")?,
+            "--audio-format",
+            "wav",
+            "--audio-quality",
+            "0",
+            "-o",
+            dest.to_str().ok_or("invalid dest path")?,
             url,
         ])
         .output()
@@ -21,7 +28,10 @@ pub fn from_youtube(url: &str, dest: &Path) -> Result<(), String> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("yt-dlp failed (ffmpeg-location={:?}): {stderr}", ffmpeg_dir));
+        return Err(format!(
+            "yt-dlp failed (ffmpeg-location={:?}): {stderr}",
+            ffmpeg_dir
+        ));
     }
     Ok(())
 }
@@ -29,18 +39,24 @@ pub fn from_youtube(url: &str, dest: &Path) -> Result<(), String> {
 /// For a local file: convert to WAV at `dest` via ffmpeg.
 /// If the file is already a WAV, copies it directly.
 pub fn from_local(src: &Path, dest: &Path) -> Result<(), String> {
-    let ext = src.extension().and_then(|e| e.to_str()).unwrap_or("").to_lowercase();
+    let ext = src
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
 
     if ext == "wav" {
-        std::fs::copy(src, dest)
-            .map_err(|e| format!("failed to copy WAV: {e}"))?;
+        std::fs::copy(src, dest).map_err(|e| format!("failed to copy WAV: {e}"))?;
     } else {
         let output = Command::new(bins::resolve("ffmpeg"))
             .args([
                 "-y",
-                "-i", src.to_str().ok_or("invalid src path")?,
-                "-ar", "44100",
-                "-ac", "2",
+                "-i",
+                src.to_str().ok_or("invalid src path")?,
+                "-ar",
+                "44100",
+                "-ac",
+                "2",
                 dest.to_str().ok_or("invalid dest path")?,
             ])
             .output()
@@ -57,9 +73,19 @@ pub fn from_local(src: &Path, dest: &Path) -> Result<(), String> {
 /// Extract a title from a YouTube URL using yt-dlp (best-effort).
 pub fn youtube_title(url: &str) -> Option<String> {
     let ffmpeg = bins::resolve("ffmpeg");
-    let ffmpeg_dir = ffmpeg.parent().map(|p| p.to_path_buf()).unwrap_or(ffmpeg.clone());
+    let ffmpeg_dir = ffmpeg
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or(ffmpeg.clone());
     let output = Command::new(bins::resolve("yt-dlp"))
-        .args(["--ffmpeg-location", ffmpeg_dir.to_str()?, "--print", "title", "--no-download", url])
+        .args([
+            "--ffmpeg-location",
+            ffmpeg_dir.to_str()?,
+            "--print",
+            "title",
+            "--no-download",
+            url,
+        ])
         .output()
         .ok()?;
     if output.status.success() {

--- a/core/src/pipeline/mod.rs
+++ b/core/src/pipeline/mod.rs
@@ -18,7 +18,8 @@ const EVENT: &str = "pipeline";
 /// can emit an error event and abort rather than silently continuing with
 /// potentially corrupt state.
 fn lock_db(db: &Mutex<Connection>) -> Result<std::sync::MutexGuard<'_, Connection>, String> {
-    db.lock().map_err(|_| "database mutex is poisoned".to_string())
+    db.lock()
+        .map_err(|_| "database mutex is poisoned".to_string())
 }
 
 /// Acquire the DB mutex or emit a stage error and return from the caller.
@@ -26,17 +27,27 @@ macro_rules! lock_or_abort {
     ($db:expr, $app:expr, $track_id:expr, $stage:literal) => {
         match lock_db($db) {
             Ok(c) => c,
-            Err(e) => { emit($app, $track_id, $stage, "error", Some(e)); return; }
+            Err(e) => {
+                emit($app, $track_id, $stage, "error", Some(e));
+                return;
+            }
         }
     };
 }
 
 /// Write the stage result to the DB: "done" on success, "error" + message on failure.
 /// Returns `Err` if the DB write itself fails so the caller can emit an error event and abort.
-fn commit_result(conn: &Connection, track_id: &str, field: &str, result: &Result<(), String>) -> Result<(), String> {
+fn commit_result(
+    conn: &Connection,
+    track_id: &str,
+    field: &str,
+    result: &Result<(), String>,
+) -> Result<(), String> {
     match result {
         Ok(_) => db::update_status(conn, track_id, field, "done", None).map_err(|e| e.to_string()),
-        Err(e) => db::update_status(conn, track_id, field, "error", Some(e)).map_err(|e| e.to_string()),
+        Err(e) => {
+            db::update_status(conn, track_id, field, "error", Some(e)).map_err(|e| e.to_string())
+        }
     }
 }
 
@@ -49,8 +60,22 @@ struct PipelineEvent<'a> {
     message: Option<String>,
 }
 
-fn emit<R: Runtime>(app: &AppHandle<R>, track_id: &str, stage: &str, status: &str, message: Option<String>) {
-    if let Err(e) = app.emit(EVENT, PipelineEvent { track_id, stage, status, message }) {
+fn emit<R: Runtime>(
+    app: &AppHandle<R>,
+    track_id: &str,
+    stage: &str,
+    status: &str,
+    message: Option<String>,
+) {
+    if let Err(e) = app.emit(
+        EVENT,
+        PipelineEvent {
+            track_id,
+            stage,
+            status,
+            message,
+        },
+    ) {
         // TODO: replace with structured logging once #22 lands
         eprintln!("[pipeline] emit failed for track={track_id} stage={stage}: {e}");
     }
@@ -86,7 +111,9 @@ pub async fn run<R: Runtime>(
 
     // --- Stage 1: download ---
     if matches!(start_stage, StartStage::Download) {
-        if token.is_cancelled() { return; }
+        if token.is_cancelled() {
+            return;
+        }
         emit(&app, &track_id, "download", "started", None);
         let dl_result = tokio::task::spawn_blocking({
             let source_wav = source_wav.clone();
@@ -101,25 +128,42 @@ pub async fn run<R: Runtime>(
         {
             let conn = lock_or_abort!(&db, &app, &track_id, "download");
             if let Err(e) = commit_result(&conn, &track_id, "status_download", &dl_result) {
-                emit(&app, &track_id, "download", "error", Some(format!("failed to write status: {e}")));
+                emit(
+                    &app,
+                    &track_id,
+                    "download",
+                    "error",
+                    Some(format!("failed to write status: {e}")),
+                );
                 return;
             }
         }
         match dl_result {
             Ok(_) => emit(&app, &track_id, "download", "done", None),
-            Err(e) => { emit(&app, &track_id, "download", "error", Some(e)); return; }
+            Err(e) => {
+                emit(&app, &track_id, "download", "error", Some(e));
+                return;
+            }
         }
     }
 
     // --- Stage 2: stems ---
     if matches!(start_stage, StartStage::Download | StartStage::Stems) {
         let Some(demucs_bin) = setup::resolve_binary(&demucs_dir) else {
-            emit(&app, &track_id, "stems", "error", Some("demucs not found".to_string()));
+            emit(
+                &app,
+                &track_id,
+                "stems",
+                "error",
+                Some("demucs not found".to_string()),
+            );
             return;
         };
         let cache_dir = setup::cache_dir(&demucs_dir);
 
-        if token.is_cancelled() { return; }
+        if token.is_cancelled() {
+            return;
+        }
         emit(&app, &track_id, "stems", "started", None);
         let stems_result = tokio::task::spawn_blocking({
             let source_wav = source_wav.clone();
@@ -132,23 +176,40 @@ pub async fn run<R: Runtime>(
         {
             let conn = lock_or_abort!(&db, &app, &track_id, "stems");
             if let Err(e) = commit_result(&conn, &track_id, "status_stems", &stems_result) {
-                emit(&app, &track_id, "stems", "error", Some(format!("failed to write status: {e}")));
+                emit(
+                    &app,
+                    &track_id,
+                    "stems",
+                    "error",
+                    Some(format!("failed to write status: {e}")),
+                );
                 return;
             }
         }
         match stems_result {
             Ok(_) => emit(&app, &track_id, "stems", "done", None),
-            Err(e) => { emit(&app, &track_id, "stems", "error", Some(e)); return; }
+            Err(e) => {
+                emit(&app, &track_id, "stems", "error", Some(e));
+                return;
+            }
         }
     }
 
     // --- Stage 3: analysis ---
-    if token.is_cancelled() { return; }
+    if token.is_cancelled() {
+        return;
+    }
     // TODO: re-enable analysis once beat/note detection is ready (MVP v2)
     {
         let conn = lock_or_abort!(&db, &app, &track_id, "analysis");
         if let Err(e) = db::update_status(&conn, &track_id, "status_analysis", "done", None) {
-            emit(&app, &track_id, "analysis", "error", Some(format!("failed to write status: {e}")));
+            emit(
+                &app,
+                &track_id,
+                "analysis",
+                "error",
+                Some(format!("failed to write status: {e}")),
+            );
             return;
         }
     }
@@ -166,22 +227,26 @@ mod tests {
     }
 
     fn insert_pending(conn: &Connection, id: &str) {
-        crate::db::insert_track(conn, &crate::db::Track {
-            id: id.to_string(),
-            title: "t".to_string(),
-            source_type: "youtube".to_string(),
-            source_url: None,
-            source_path: None,
-            created_at: "2024-01-01T00:00:00Z".to_string(),
-            sort_order: 1,
-            duration_ms: None,
-            status_download: "pending".to_string(),
-            status_stems: "pending".to_string(),
-            status_analysis: "pending".to_string(),
-            error_message: None,
-            export_path: None,
-            artist: None,
-        }).unwrap();
+        crate::db::insert_track(
+            conn,
+            &crate::db::Track {
+                id: id.to_string(),
+                title: "t".to_string(),
+                source_type: "youtube".to_string(),
+                source_url: None,
+                source_path: None,
+                created_at: "2024-01-01T00:00:00Z".to_string(),
+                sort_order: 1,
+                duration_ms: None,
+                status_download: "pending".to_string(),
+                status_stems: "pending".to_string(),
+                status_analysis: "pending".to_string(),
+                error_message: None,
+                export_path: None,
+                artist: None,
+            },
+        )
+        .unwrap();
     }
 
     #[test]
@@ -213,7 +278,13 @@ mod tests {
     fn commit_result_err_sets_error_and_message() {
         let conn = open_mem();
         insert_pending(&conn, "t2");
-        assert!(commit_result(&conn, "t2", "status_stems", &Err("demucs crashed".to_string())).is_ok());
+        assert!(commit_result(
+            &conn,
+            "t2",
+            "status_stems",
+            &Err("demucs crashed".to_string())
+        )
+        .is_ok());
         let track = crate::db::get_track(&conn, "t2").unwrap().unwrap();
         assert_eq!(track.status_stems, "error");
         assert_eq!(track.error_message.as_deref(), Some("demucs crashed"));

--- a/core/src/pipeline/stems.rs
+++ b/core/src/pipeline/stems.rs
@@ -25,8 +25,10 @@ pub fn separate(
 
         let output = Command::new(demucs_bin)
             .args([
-                "--name", "htdemucs",
-                "-o", tmp.to_str().ok_or("invalid tmp path")?,
+                "--name",
+                "htdemucs",
+                "-o",
+                tmp.to_str().ok_or("invalid tmp path")?,
                 source_wav.to_str().ok_or("invalid source_wav path")?,
             ])
             .env("TORCH_HOME", cache_dir)

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -1,16 +1,13 @@
-use std::path::{Path, PathBuf};
 use futures_util::StreamExt;
 use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Emitter};
 
 /// Update this to your GitHub repo (owner/name).
 const GITHUB_REPO: &str = "asawo/wavesplit";
 const RELEASE_TAG: &str = "demucs-sidecar";
 
-async fn fetch_expected_sha256(
-    client: &reqwest::Client,
-    asset: &str,
-) -> Result<String, String> {
+async fn fetch_expected_sha256(client: &reqwest::Client, asset: &str) -> Result<String, String> {
     let url = format!(
         "https://github.com/{}/releases/download/{}/checksums.txt",
         GITHUB_REPO, RELEASE_TAG
@@ -21,7 +18,10 @@ async fn fetch_expected_sha256(
         .await
         .map_err(|e| format!("failed to fetch checksums.txt: {e}"))?;
     if !response.status().is_success() {
-        return Err(format!("failed to fetch checksums.txt: HTTP {}", response.status()));
+        return Err(format!(
+            "failed to fetch checksums.txt: HTTP {}",
+            response.status()
+        ));
     }
     let body = response
         .text()
@@ -112,15 +112,16 @@ fn remove_quarantine(dest: &Path) -> Result<(), String> {
 }
 
 pub async fn download(demucs_dir: &Path, app: &AppHandle) -> Result<(), String> {
-    std::fs::create_dir_all(demucs_dir)
-        .map_err(|e| format!("failed to create demucs dir: {e}"))?;
+    std::fs::create_dir_all(demucs_dir).map_err(|e| format!("failed to create demucs dir: {e}"))?;
 
     let client = reqwest::Client::new();
     let expected = fetch_expected_sha256(&client, asset_name()).await?;
 
     let url = format!(
         "https://github.com/{}/releases/download/{}/{}",
-        GITHUB_REPO, RELEASE_TAG, asset_name()
+        GITHUB_REPO,
+        RELEASE_TAG,
+        asset_name()
     );
     let response = client
         .get(&url)
@@ -154,15 +155,20 @@ pub async fn download(demucs_dir: &Path, app: &AppHandle) -> Result<(), String> 
             .await
             .map_err(|e| format!("write error: {e}"))?;
 
-        let _ = app.emit("setup:progress", DownloadProgress {
-            downloaded_mb: downloaded as f64 / 1_048_576.0,
-            total_mb: total_bytes.map(|t| t as f64 / 1_048_576.0),
-            percent: total_bytes.map(|t| (downloaded * 100 / t) as u32),
-        });
+        let _ = app.emit(
+            "setup:progress",
+            DownloadProgress {
+                downloaded_mb: downloaded as f64 / 1_048_576.0,
+                total_mb: total_bytes.map(|t| t as f64 / 1_048_576.0),
+                percent: total_bytes.map(|t| (downloaded * 100 / t) as u32),
+            },
+        );
     }
 
     use tokio::io::AsyncWriteExt;
-    file.flush().await.map_err(|e| format!("flush error: {e}"))?;
+    file.flush()
+        .await
+        .map_err(|e| format!("flush error: {e}"))?;
     drop(file);
 
     let actual = hex::encode(hasher.finalize());

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,32 +1,11 @@
 {
   "compilerOptions": {
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "target": "ESNext",
     "module": "ESNext",
-    /**
-     * svelte-preprocess cannot figure out whether you have
-     * a value or a type, so tell TypeScript to enforce using
-     * `import type` instead of `import` for Types.
-     */
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "resolveJsonModule": true,
-    /**
-     * To have warnings / errors of the Svelte compiler at the
-     * correct position, enable source maps by default.
-     */
-    "sourceMap": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    /**
-     * Typecheck JS in `.svelte` and `.js` files by default.
-     * Disable this if you'd like to use dynamic types.
-     */
-    "checkJs": true
+    "checkJs": true,
+    "strict": false,
+    "noImplicitAny": false
   },
-  /**
-   * Use global.d.ts instead of compilerOptions.types
-   * to avoid limiting type declarations.
-   */
-  "include": ["ui/**/*.d.ts", "ui/**/*.js", "ui/**/*.svelte"]
+  "exclude": ["node_modules", "dist", "**/*.test.js"]
 }

--- a/justfile
+++ b/justfile
@@ -110,12 +110,45 @@ test:
 fmt:
     source "$HOME/.cargo/env" && cargo fmt --manifest-path core/Cargo.toml
 
+# Check Rust formatting without modifying files
+fmt-check:
+    source "$HOME/.cargo/env" && cargo fmt --manifest-path core/Cargo.toml --check
+
 # Lint Rust code
 lint:
     source "$HOME/.cargo/env" && cargo clippy --manifest-path core/Cargo.toml -- -D warnings
 
-# Run all CI checks locally (clippy + test)
-ci: lint test
+# Auto-format Rust and frontend code
+fix:
+    source "$HOME/.cargo/env" && cargo fmt --manifest-path core/Cargo.toml
+    pnpm run format
+
+# Type-check Svelte components
+check-ui:
+    pnpm run check
+
+# Check frontend formatting (Prettier)
+lint-ui:
+    pnpm run format:check
+
+# Build frontend only (Vite, no Tauri)
+build-ui:
+    pnpm run build
+
+# Run all CI checks locally — mirrors what CI runs on push/PR
+ci: fmt-check lint test build-ui check-ui lint-ui
+
+# Install git pre-commit hook (run once after cloning)
+install-hooks:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cat > .git/hooks/pre-commit << 'HOOK'
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just fmt-check && just lint && just check-ui
+    HOOK
+    chmod +x .git/hooks/pre-commit
+    echo "pre-commit hook installed"
 
 # Open app data directory (macOS)
 open-data:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "build": "vite build",
     "preview": "vite preview",
     "tauri": "tauri",
-    "test": "vitest run"
+    "test": "vitest run",
+    "check": "svelte-check",
+    "format": "prettier --write \"ui/**/*.{svelte,js,css}\"",
+    "format:check": "prettier --check \"ui/**/*.{svelte,js,css}\""
   },
   "dependencies": {
     "@fontsource/oleo-script-swash-caps": "^5.2.8",
@@ -21,7 +24,10 @@
     "@tauri-apps/cli": "^2",
     "@testing-library/svelte": "^5.0.0",
     "happy-dom": "^20.8.9",
+    "prettier": "^3.4.0",
+    "prettier-plugin-svelte": "^3.4.0",
     "svelte": "^5.1.3",
+    "svelte-check": "^4.0.0",
     "vite": "^5.4.10",
     "vitest": "^2.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,9 +31,18 @@ devDependencies:
   happy-dom:
     specifier: ^20.8.9
     version: 20.8.9
+  prettier:
+    specifier: ^3.4.0
+    version: 3.8.3
+  prettier-plugin-svelte:
+    specifier: ^3.4.0
+    version: 3.5.1(prettier@3.8.3)(svelte@5.55.1)
   svelte:
     specifier: ^5.1.3
     version: 5.55.1
+  svelte-check:
+    specifier: ^4.0.0
+    version: 4.4.6(svelte@5.55.1)(typescript@6.0.3)
   vite:
     specifier: ^5.4.10
     version: 5.4.21
@@ -874,6 +883,13 @@ packages:
     engines: {node: '>= 16'}
     dev: true
 
+  /chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+    dependencies:
+      readdirp: 4.1.2
+    dev: true
+
   /clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -976,6 +992,16 @@ packages:
     engines: {node: '>=12.0.0'}
     dev: true
 
+  /fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+    dev: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1033,6 +1059,11 @@ packages:
       '@jridgewell/sourcemap-codec': 1.5.5
     dev: true
 
+  /mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+    dev: true
+
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
@@ -1065,6 +1096,22 @@ packages:
       source-map-js: 1.2.1
     dev: true
 
+  /prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.55.1):
+    resolution: {integrity: sha512-65+fr5+cgIKWKiqM1Doum4uX6bY8iFCdztvvp2RcF+AJoieaw9kJOFMNcJo/bkmKYsxFaM9OsVZK/gWauG/5mg==}
+    peerDependencies:
+      prettier: ^3.0.0
+      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
+    dependencies:
+      prettier: 3.8.3
+      svelte: 5.55.1
+    dev: true
+
+  /prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
+
   /pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -1076,6 +1123,11 @@ packages:
 
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+    dev: true
+
+  /readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
     dev: true
 
   /rollup@4.60.1:
@@ -1113,6 +1165,13 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+    dependencies:
+      mri: 1.2.0
+    dev: true
+
   /siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
     dev: true
@@ -1128,6 +1187,25 @@ packages:
 
   /std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+    dev: true
+
+  /svelte-check@4.4.6(svelte@5.55.1)(typescript@6.0.3):
+    resolution: {integrity: sha512-kP1zG81EWaFe9ZyTv4ZXv44Csi6Pkdpb7S3oj6m+K2ec/IcDg/a8LsFsnVLqm2nxtkSwsd5xPj/qFkTBgXHXjg==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: '>=5.0.0'
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      chokidar: 4.0.3
+      fdir: 6.5.0
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.55.1
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - picomatch
     dev: true
 
   /svelte@5.55.1:
@@ -1173,6 +1251,12 @@ packages:
   /tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
+    dev: true
+
+  /typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
     dev: true
 
   /undici-types@7.19.2:

--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -1,27 +1,27 @@
 <script>
-  import { invoke } from '@tauri-apps/api/core'
-  import { onMount } from 'svelte'
-  import AddTrack from './lib/AddTrack.svelte'
-  import TrackList from './lib/TrackList.svelte'
-  import Playback from './lib/Playback.svelte'
-  import Setup from './lib/Setup.svelte'
+  import { invoke } from "@tauri-apps/api/core";
+  import { onMount } from "svelte";
+  import AddTrack from "./lib/AddTrack.svelte";
+  import TrackList from "./lib/TrackList.svelte";
+  import Playback from "./lib/Playback.svelte";
+  import Setup from "./lib/Setup.svelte";
 
-  let tracks = $state([])
-  let refreshTracks = $state(null)
-  let ready = $state(true)  // optimistic: assume available, overlay shows if not
+  let tracks = $state([]);
+  let refreshTracks = $state(null);
+  let ready = $state(true); // optimistic: assume available, overlay shows if not
 
-  let screen = $state('library')   // 'library' | 'playback'
-  let selectedTrack = $state(null)
+  let screen = $state("library"); // 'library' | 'playback'
+  let selectedTrack = $state(null);
 
   onMount(async () => {
     try {
-      ready = await invoke('check_demucs')
+      ready = await invoke("check_demucs");
     } catch {
-      ready = false
+      ready = false;
     }
-  })
+  });
 
-  const PENDING_ID = '__pending__'
+  const PENDING_ID = "__pending__";
 
   function handleStarted(title) {
     tracks = [
@@ -30,35 +30,34 @@
         title,
         artist: null,
         sort_order: Date.now(),
-        status_download: 'pending',
-        status_stems: 'pending',
-        status_analysis: 'pending',
+        status_download: "pending",
+        status_stems: "pending",
+        status_analysis: "pending",
         error_message: null,
         export_path: null,
         duration_ms: null,
       },
       ...tracks,
-    ]
+    ];
   }
 
   function handleAdded(_id) {
-    refreshTracks?.()
+    refreshTracks?.();
   }
 
   function openPlayback(track) {
-    selectedTrack = track
-    screen = 'playback'
+    selectedTrack = track;
+    screen = "playback";
   }
 
   function closePlayback() {
-    screen = 'library'
+    screen = "library";
     // keep selectedTrack alive so playhead position is preserved on return
   }
 </script>
 
 <div class="app fade-in">
-  <div class="screens-inner" class:show-playback={screen === 'playback'}>
-
+  <div class="screens-inner" class:show-playback={screen === "playback"}>
     <!-- Library screen -->
     <div class="screen">
       <header>
@@ -71,7 +70,11 @@
         </section>
         <section class="list-section">
           <p class="section-label">Library</p>
-          <TrackList bind:tracks bind:refresh={refreshTracks} onPlay={openPlayback} />
+          <TrackList
+            bind:tracks
+            bind:refresh={refreshTracks}
+            onPlay={openPlayback}
+          />
         </section>
       </main>
     </div>
@@ -81,18 +84,17 @@
       {#if selectedTrack}
         <Playback
           track={selectedTrack}
-          active={screen === 'playback'}
+          active={screen === "playback"}
           onBack={closePlayback}
         />
       {/if}
     </div>
-
   </div>
 </div>
 
 {#if !ready}
   <div class="overlay fade-in">
-    <Setup onReady={() => ready = true} />
+    <Setup onReady={() => (ready = true)} />
   </div>
 {/if}
 
@@ -120,8 +122,12 @@
   }
 
   @keyframes fade-in {
-    from { opacity: 0; }
-    to   { opacity: 1; }
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
   }
 
   :global(.fade-in) {
@@ -132,7 +138,7 @@
     margin: 0;
     background: var(--bg);
     color: var(--fg);
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     font-size: 14px;
     -webkit-font-smoothing: antialiased;
   }
@@ -171,7 +177,7 @@
   h1 {
     margin: 0;
     font-size: 24px;
-    font-family: 'Oleo Script Swash Caps', cursive;
+    font-family: "Oleo Script Swash Caps", cursive;
     font-weight: 400;
     color: var(--color-ready);
   }

--- a/ui/declarations.d.ts
+++ b/ui/declarations.d.ts
@@ -1,0 +1,1 @@
+declare module '@fontsource/*';

--- a/ui/lib/AddTrack.svelte
+++ b/ui/lib/AddTrack.svelte
@@ -1,65 +1,73 @@
 <script>
-  import { invoke } from '@tauri-apps/api/core'
-  import { open as openDialog } from '@tauri-apps/plugin-dialog'
+  import { invoke } from "@tauri-apps/api/core";
+  import { open as openDialog } from "@tauri-apps/plugin-dialog";
 
-  let { onAdded, onStarted } = $props()
+  let { onAdded, onStarted } = $props();
 
-  let url = $state('')
-  let loading = $state(false)
-  let error = $state('')
+  let url = $state("");
+  let loading = $state(false);
+  let error = $state("");
 
-  const YOUTUBE_PATTERN = 'https://(www\\.youtube\\.com|youtu\\.be|music\\.youtube\\.com)/.+'
+  const YOUTUBE_PATTERN =
+    "https://(www\\.youtube\\.com|youtu\\.be|music\\.youtube\\.com)/.+";
 
   function normalizeUrl(value) {
-    const trimmed = value.trim()
-    if (trimmed && !/^https?:\/\//i.test(trimmed)) return 'https://' + trimmed
-    return trimmed
+    const trimmed = value.trim();
+    if (trimmed && !/^https?:\/\//i.test(trimmed)) return "https://" + trimmed;
+    return trimmed;
   }
 
   function isValidYoutubeUrl(value) {
-    return new RegExp('^' + YOUTUBE_PATTERN + '$').test(normalizeUrl(value))
+    return new RegExp("^" + YOUTUBE_PATTERN + "$").test(normalizeUrl(value));
   }
 
   let urlError = $derived(
-    url.trim() && !isValidYoutubeUrl(url) ? 'Must be a YouTube URL (youtube.com, youtu.be, music.youtube.com)' : ''
-  )
+    url.trim() && !isValidYoutubeUrl(url)
+      ? "Must be a YouTube URL (youtube.com, youtu.be, music.youtube.com)"
+      : "",
+  );
 
   async function addYoutube() {
-    if (!url.trim()) return
-    loading = true
-    error = ''
-    const pendingUrl = normalizeUrl(url)
-    url = ''
-    onStarted(pendingUrl)
+    if (!url.trim()) return;
+    loading = true;
+    error = "";
+    const pendingUrl = normalizeUrl(url);
+    url = "";
+    onStarted(pendingUrl);
     try {
-      const id = await invoke('add_track_youtube', { url: pendingUrl })
-      onAdded(id)
+      const id = await invoke("add_track_youtube", { url: pendingUrl });
+      onAdded(id);
     } catch (e) {
-      error = String(e)
-      onAdded(null)
+      error = String(e);
+      onAdded(null);
     } finally {
-      loading = false
+      loading = false;
     }
   }
 
   async function addLocal() {
     const selected = await openDialog({
       multiple: false,
-      filters: [{ name: 'Audio', extensions: ['mp3', 'wav', 'flac', 'm4a', 'aac', 'ogg'] }],
-    })
-    if (!selected) return
-    loading = true
-    error = ''
+      filters: [
+        {
+          name: "Audio",
+          extensions: ["mp3", "wav", "flac", "m4a", "aac", "ogg"],
+        },
+      ],
+    });
+    if (!selected) return;
+    loading = true;
+    error = "";
     // Normalize backslashes for Windows paths (display only — `selected` is passed as-is to the backend)
-    onStarted(selected.replace(/\\/g, '/').split('/').pop() ?? 'Local file')
+    onStarted(selected.replace(/\\/g, "/").split("/").pop() ?? "Local file");
     try {
-      const id = await invoke('add_track_local', { path: selected })
-      onAdded(id)
+      const id = await invoke("add_track_local", { path: selected });
+      onAdded(id);
     } catch (e) {
-      error = String(e)
-      onAdded(null)
+      error = String(e);
+      onAdded(null);
     } finally {
-      loading = false
+      loading = false;
     }
   }
 </script>
@@ -71,9 +79,11 @@
       placeholder="YouTube URL"
       bind:value={url}
       disabled={loading}
-      onkeydown={(e) => e.key === 'Enter' && addYoutube()}
+      onkeydown={(e) => e.key === "Enter" && addYoutube()}
     />
-    <button onclick={addYoutube} disabled={loading || !isValidYoutubeUrl(url)}>Add</button>
+    <button onclick={addYoutube} disabled={loading || !isValidYoutubeUrl(url)}
+      >Add</button
+    >
     <span class="divider">or</span>
     <button onclick={addLocal} disabled={loading}>Open file…</button>
   </div>

--- a/ui/lib/Playback.svelte
+++ b/ui/lib/Playback.svelte
@@ -1,149 +1,163 @@
 <script>
-  import { invoke, convertFileSrc } from '@tauri-apps/api/core'
-  import { open as openDialog } from '@tauri-apps/plugin-dialog'
-  import { onDestroy } from 'svelte'
-  import { formatTime, hashStr, makeWaveformBars, extractWaveform, waveformGradientId } from './playback.helpers.js'
+  import { invoke, convertFileSrc } from "@tauri-apps/api/core";
+  import { open as openDialog } from "@tauri-apps/plugin-dialog";
+  import { onDestroy } from "svelte";
+  import {
+    formatTime,
+    hashStr,
+    makeWaveformBars,
+    extractWaveform,
+    waveformGradientId,
+  } from "./playback.helpers.js";
 
-  let { track, active, onBack } = $props()
+  let { track, active, onBack } = $props();
 
   const STEMS = [
-    { key: 'vocals', label: 'Vocals', color: '#4caf72' },
-    { key: 'drums',  label: 'Drums',  color: '#4a9eff' },
-    { key: 'bass',   label: 'Bass',   color: '#f0a030' },
-    { key: 'other',  label: 'Other',  color: '#e06080' },
-  ]
+    { key: "vocals", label: "Vocals", color: "#4caf72" },
+    { key: "drums", label: "Drums", color: "#4a9eff" },
+    { key: "bass", label: "Bass", color: "#f0a030" },
+    { key: "other", label: "Other", color: "#e06080" },
+  ];
 
   // ── Transport ──────────────────────────────────────────────
-  let playing = $state(false)
-  let playhead = $state(0)   // 0–1 fraction
+  let playing = $state(false);
+  let playhead = $state(0); // 0–1 fraction
 
   // ── Stem mixer ─────────────────────────────────────────────
   let stemState = $state(
-    Object.fromEntries(STEMS.map(s => [s.key, { muted: false, soloed: false, volume: 1 }]))
-  )
+    Object.fromEntries(
+      STEMS.map((s) => [s.key, { muted: false, soloed: false, volume: 1 }]),
+    ),
+  );
 
   function toggleMute(key) {
-    stemState[key] = { ...stemState[key], muted: !stemState[key].muted }
+    stemState[key] = { ...stemState[key], muted: !stemState[key].muted };
   }
 
   function toggleSolo(key) {
-    const wasSoloed = stemState[key].soloed
-    for (const k of Object.keys(stemState)) stemState[k] = { ...stemState[k], soloed: false }
-    if (!wasSoloed) stemState[key] = { ...stemState[key], soloed: true }
+    const wasSoloed = stemState[key].soloed;
+    for (const k of Object.keys(stemState))
+      stemState[k] = { ...stemState[k], soloed: false };
+    if (!wasSoloed) stemState[key] = { ...stemState[key], soloed: true };
   }
 
-  let anySoloed = $derived(Object.values(stemState).some(s => s.soloed))
+  let anySoloed = $derived(Object.values(stemState).some((s) => s.soloed));
 
   function isMuted(key) {
-    return anySoloed ? !stemState[key].soloed : stemState[key].muted
+    return anySoloed ? !stemState[key].soloed : stemState[key].muted;
   }
 
   // ── Audio engine ───────────────────────────────────────────
-  let audioCtx = null
-  let gainNodes = {}       // key → GainNode
-  let sourceNodes = {}     // key → AudioBufferSourceNode (live while playing)
-  let buffers = $state({}) // key → AudioBuffer
-  let waveformData = $state({}) // key → number[120] (RMS, 0–1 normalised)
-  let loading = $state(false)
-  let loadError = $state(null)
-  let duration = $state(0) // seconds (from decoded audio)
-  let startOffset = 0      // track pos (s) where last play() started from
-  let startTime = 0        // audioCtx.currentTime when last play() started
-  let rafId = null
-  let loadedTrackId = null
+  let audioCtx = null;
+  let gainNodes = {}; // key → GainNode
+  let sourceNodes = {}; // key → AudioBufferSourceNode (live while playing)
+  let buffers = $state({}); // key → AudioBuffer
+  let waveformData = $state({}); // key → number[120] (RMS, 0–1 normalised)
+  let loading = $state(false);
+  let loadError = $state(null);
+  let duration = $state(0); // seconds (from decoded audio)
+  let startOffset = 0; // track pos (s) where last play() started from
+  let startTime = 0; // audioCtx.currentTime when last play() started
+  let rafId = null;
+  let loadedTrackId = null;
 
   // Time display — prefer real decoded duration, fall back to DB
-  let displayDuration = $derived(duration > 0 ? duration : (track.duration_ms ?? 0) / 1000)
-  let elapsedSeconds = $derived(playhead * displayDuration)
+  let displayDuration = $derived(
+    duration > 0 ? duration : (track.duration_ms ?? 0) / 1000,
+  );
+  let elapsedSeconds = $derived(playhead * displayDuration);
 
-  const masterGradId = $derived(waveformGradientId(track.id, 'master'))
+  const masterGradId = $derived(waveformGradientId(track.id, "master"));
 
   // Master waveform = RMS average of all loaded stems
-  let masterWaveform = $derived((() => {
-    const loaded = STEMS.map(s => waveformData[s.key]).filter(Boolean)
-    if (!loaded.length) return null
-    const avg = new Array(120).fill(0)
-    for (const w of loaded) {
-      for (let i = 0; i < 120; i++) avg[i] += w[i] / loaded.length
-    }
-    return avg
-  })())
+  let masterWaveform = $derived(
+    (() => {
+      const loaded = STEMS.map((s) => waveformData[s.key]).filter(Boolean);
+      if (!loaded.length) return null;
+      const avg = new Array(120).fill(0);
+      for (const w of loaded) {
+        for (let i = 0; i < 120; i++) avg[i] += w[i] / loaded.length;
+      }
+      return avg;
+    })(),
+  );
 
   function applyGains() {
     for (const stem of STEMS) {
       // Read reactive state first so $effect always tracks these as dependencies,
       // even before gain nodes are created (early-return would skip the reads).
-      const s = stemState[stem.key]
-      const muted = anySoloed ? !s.soloed : s.muted
-      const target = muted ? 0 : s.volume
-      const node = gainNodes[stem.key]
-      if (!node) continue
+      const s = stemState[stem.key];
+      const muted = anySoloed ? !s.soloed : s.muted;
+      const target = muted ? 0 : s.volume;
+      const node = gainNodes[stem.key];
+      if (!node) continue;
       if (audioCtx) {
-        node.gain.setTargetAtTime(target, audioCtx.currentTime, 0.015)
+        node.gain.setTargetAtTime(target, audioCtx.currentTime, 0.015);
       } else {
-        node.gain.value = target
+        node.gain.value = target;
       }
     }
   }
 
   async function loadAudio() {
-    const targetId = track.id
-    if (loadedTrackId === targetId) return
-    loadedTrackId = targetId
+    const targetId = track.id;
+    if (loadedTrackId === targetId) return;
+    loadedTrackId = targetId;
 
-    cancelTick()
-    stopSources()
+    cancelTick();
+    stopSources();
 
-    loading = true
-    loadError = null
-    playing = false
-    startOffset = 0
-    playhead = 0
-    buffers = {}
-    waveformData = {}
+    loading = true;
+    loadError = null;
+    playing = false;
+    startOffset = 0;
+    playhead = 0;
+    buffers = {};
+    waveformData = {};
 
     try {
       if (!audioCtx) {
-        audioCtx = new AudioContext()
-        audioCtx.addEventListener('statechange', () => {
-          if (playing && audioCtx.state === 'suspended') audioCtx.resume()
-        })
+        audioCtx = new AudioContext();
+        audioCtx.addEventListener("statechange", () => {
+          if (playing && audioCtx.state === "suspended") audioCtx.resume();
+        });
         for (const stem of STEMS) {
-          gainNodes[stem.key] = audioCtx.createGain()
-          gainNodes[stem.key].connect(audioCtx.destination)
+          gainNodes[stem.key] = audioCtx.createGain();
+          gainNodes[stem.key].connect(audioCtx.destination);
         }
-        applyGains()
+        applyGains();
       }
 
-      const paths = await invoke('get_stem_paths', { trackId: targetId })
+      const paths = await invoke("get_stem_paths", { trackId: targetId });
 
-      const results = await Promise.all(STEMS.map(async ({ key }) => {
-        const url = convertFileSrc(paths[key])
-        const resp = await fetch(url)
-        if (!resp.ok) throw new Error(`HTTP ${resp.status} for ${key}`)
-        const ab = await resp.arrayBuffer()
-        const buf = await audioCtx.decodeAudioData(ab)
-        return [key, buf]
-      }))
+      const results = await Promise.all(
+        STEMS.map(async ({ key }) => {
+          const url = convertFileSrc(paths[key]);
+          const resp = await fetch(url);
+          if (!resp.ok) throw new Error(`HTTP ${resp.status} for ${key}`);
+          const ab = await resp.arrayBuffer();
+          const buf = await audioCtx.decodeAudioData(ab);
+          return [key, buf];
+        }),
+      );
 
       // Discard results if the user switched tracks while we were loading
-      if (loadedTrackId !== targetId) return
+      if (loadedTrackId !== targetId) return;
 
-      const newBuffers = Object.fromEntries(results)
-      buffers = newBuffers
+      const newBuffers = Object.fromEntries(results);
+      buffers = newBuffers;
       waveformData = Object.fromEntries(
-        results.map(([key, buf]) => [key, extractWaveform(buf, 120)])
-      )
-      duration = Object.values(newBuffers)[0]?.duration ?? 0
-
+        results.map(([key, buf]) => [key, extractWaveform(buf, 120)]),
+      );
+      duration = Object.values(newBuffers)[0]?.duration ?? 0;
     } catch (e) {
       if (loadedTrackId === targetId) {
-        loadError = e.message ?? String(e)
-        loadedTrackId = null  // allow retry on next open
+        loadError = e.message ?? String(e);
+        loadedTrackId = null; // allow retry on next open
       }
     } finally {
       if (loadedTrackId === targetId || loadedTrackId === null) {
-        loading = false
+        loading = false;
       }
     }
   }
@@ -151,135 +165,155 @@
   // ── Playback control ───────────────────────────────────────
 
   async function startPlayback() {
-    if (!audioCtx || Object.keys(buffers).length === 0) return
-    if (audioCtx.state !== 'running') await audioCtx.resume()
-    const offset = Math.max(0, Math.min(startOffset, duration - 0.01))
-    startTime = audioCtx.currentTime
+    if (!audioCtx || Object.keys(buffers).length === 0) return;
+    if (audioCtx.state !== "running") await audioCtx.resume();
+    const offset = Math.max(0, Math.min(startOffset, duration - 0.01));
+    startTime = audioCtx.currentTime;
     for (const { key } of STEMS) {
-      const buf = buffers[key]
-      if (!buf) continue
-      const src = audioCtx.createBufferSource()
-      src.buffer = buf
-      src.connect(gainNodes[key])
-      src.start(0, offset)
-      sourceNodes[key] = src
+      const buf = buffers[key];
+      if (!buf) continue;
+      const src = audioCtx.createBufferSource();
+      src.buffer = buf;
+      src.connect(gainNodes[key]);
+      src.start(0, offset);
+      sourceNodes[key] = src;
     }
-    schedTick()
+    schedTick();
   }
 
   function stopSources() {
     for (const src of Object.values(sourceNodes)) {
-      try { src.stop() } catch (_) {}
-      try { src.disconnect() } catch (_) {}
+      try {
+        src.stop();
+      } catch (_) {}
+      try {
+        src.disconnect();
+      } catch (_) {}
     }
-    sourceNodes = {}
+    sourceNodes = {};
   }
 
   function pausePlayback() {
     if (audioCtx && Object.keys(sourceNodes).length > 0) {
-      startOffset = Math.min(startOffset + (audioCtx.currentTime - startTime), duration)
+      startOffset = Math.min(
+        startOffset + (audioCtx.currentTime - startTime),
+        duration,
+      );
     }
-    stopSources()
-    cancelTick()
+    stopSources();
+    cancelTick();
   }
 
   async function handlePlayPause() {
-    if (!audioCtx || Object.keys(buffers).length === 0) return
+    if (!audioCtx || Object.keys(buffers).length === 0) return;
     if (playing) {
-      pausePlayback()
-      playing = false
+      pausePlayback();
+      playing = false;
     } else {
-      await startPlayback()
-      playing = true
+      await startPlayback();
+      playing = true;
     }
   }
 
   async function seek(fraction) {
-    const safeFraction = Math.max(0, Math.min(1, fraction))
-    const was = playing
-    if (was) { stopSources(); cancelTick(); playing = false }
-    startOffset = safeFraction * duration
-    playhead = safeFraction
+    const safeFraction = Math.max(0, Math.min(1, fraction));
+    const was = playing;
     if (was) {
-      await startPlayback()
-      playing = true
+      stopSources();
+      cancelTick();
+      playing = false;
+    }
+    startOffset = safeFraction * duration;
+    playhead = safeFraction;
+    if (was) {
+      await startPlayback();
+      playing = true;
     }
   }
 
   function seekToClick(e) {
-    const rect = e.currentTarget.getBoundingClientRect()
-    seek((e.clientX - rect.left) / rect.width)
+    const rect = e.currentTarget.getBoundingClientRect();
+    seek((e.clientX - rect.left) / rect.width);
   }
 
   function getCurrentPos() {
-    if (!playing || !audioCtx) return startOffset
-    return startOffset + (audioCtx.currentTime - startTime)
+    if (!playing || !audioCtx) return startOffset;
+    return startOffset + (audioCtx.currentTime - startTime);
   }
 
   function skipBy(seconds) {
-    seek((getCurrentPos() + seconds) / Math.max(duration, 0.001))
+    seek((getCurrentPos() + seconds) / Math.max(duration, 0.001));
   }
 
   function schedTick() {
-    cancelTick()
-    rafId = requestAnimationFrame(tick)
+    cancelTick();
+    rafId = requestAnimationFrame(tick);
   }
 
   function cancelTick() {
-    if (rafId) { cancelAnimationFrame(rafId); rafId = null }
+    if (rafId) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
   }
 
   function tick() {
-    if (!playing || !audioCtx) return
-    const pos = startOffset + (audioCtx.currentTime - startTime)
+    if (!playing || !audioCtx) return;
+    const pos = startOffset + (audioCtx.currentTime - startTime);
     if (pos >= duration) {
-      stopSources()
-      playing = false
-      startOffset = 0
-      playhead = 0
-      return
+      stopSources();
+      playing = false;
+      startOffset = 0;
+      playhead = 0;
+      return;
     }
-    playhead = pos / duration
-    rafId = requestAnimationFrame(tick)
+    playhead = pos / duration;
+    rafId = requestAnimationFrame(tick);
   }
 
   // Sync gain nodes whenever stem state or solo changes
   $effect(() => {
-    applyGains()
-  })
+    applyGains();
+  });
 
   // Pause when navigating back to library
   $effect(() => {
-    if (!active && playing) { pausePlayback(); playing = false }
-  })
+    if (!active && playing) {
+      pausePlayback();
+      playing = false;
+    }
+  });
 
   // Reload whenever the selected track changes
   $effect(() => {
-    const id = track.id  // reactive — re-runs when track changes
-    if (id !== loadedTrackId) loadAudio()
-  })
+    const id = track.id; // reactive — re-runs when track changes
+    if (id !== loadedTrackId) loadAudio();
+  });
 
   onDestroy(() => {
-    cancelTick()
-    stopSources()
-    audioCtx?.close()
-  })
+    cancelTick();
+    stopSources();
+    audioCtx?.close();
+  });
 
   // ── Export ─────────────────────────────────────────────────
-  let exportingId = $state(null)
-  let exportError = $state('')
+  let exportingId = $state(null);
+  let exportError = $state("");
 
   async function exportStems() {
-    const dest = await openDialog({ directory: true, title: 'Export stems to…' })
-    if (!dest) return
-    exportingId = track.id
-    exportError = ''
+    const dest = await openDialog({
+      directory: true,
+      title: "Export stems to…",
+    });
+    if (!dest) return;
+    exportingId = track.id;
+    exportError = "";
     try {
-      await invoke('export_stems', { trackId: track.id, destDir: dest })
+      await invoke("export_stems", { trackId: track.id, destDir: dest });
     } catch (e) {
-      exportError = String(e)
+      exportError = String(e);
     } finally {
-      exportingId = null
+      exportingId = null;
     }
   }
 </script>
@@ -300,21 +334,37 @@
     <p class="section-label">Master</p>
     <div class="master-panel">
       <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions a11y_no_noninteractive_element_interactions -->
-      <div class="waveform-wrap" role="presentation" onclick={seekToClick}
-           style="opacity:{loading ? 0.4 : 1}; transition:opacity 0.3s">
+      <div
+        class="waveform-wrap"
+        role="presentation"
+        onclick={seekToClick}
+        style="opacity:{loading ? 0.4 : 1}; transition:opacity 0.3s"
+      >
         <svg class="waveform" viewBox="0 0 400 60" preserveAspectRatio="none">
           <defs>
-            <linearGradient id={masterGradId}
-                            gradientUnits="userSpaceOnUse" x1="0" x2="400" y1="0" y2="0">
+            <linearGradient
+              id={masterGradId}
+              gradientUnits="userSpaceOnUse"
+              x1="0"
+              x2="400"
+              y1="0"
+              y2="0"
+            >
               <stop offset="{playhead * 100}%" stop-color="#4caf72" />
               <stop offset="{playhead * 100}%" stop-color="#383838" />
             </linearGradient>
           </defs>
-          {#each (masterWaveform ?? makeWaveformBars(track.id, 120)) as h, i}
+          {#each masterWaveform ?? makeWaveformBars(track.id, 120) as h, i}
             {@const x = i * (400 / 120)}
             {@const bh = h * 54}
-            <rect x={x} y={(60 - bh) / 2} width="2.2" height={bh} rx="1"
-                  fill="url(#{masterGradId})" />
+            <rect
+              {x}
+              y={(60 - bh) / 2}
+              width="2.2"
+              height={bh}
+              rx="1"
+              fill="url(#{masterGradId})"
+            />
           {/each}
         </svg>
         <div class="playhead" style="left:{playhead * 100}%">
@@ -330,16 +380,26 @@
 
   <!-- ── Transport ── -->
   <div class="transport">
-    <button class="transport-btn" title="Skip to start" onclick={() => seek(0)}>‹</button>
-    <button class="transport-btn" title="Rewind 10s"    onclick={() => skipBy(-10)}>‹‹</button>
-    <button class="transport-btn play-btn"
-            title={playing ? 'Pause' : 'Play'}
-            disabled={loading || !!loadError}
-            onclick={handlePlayPause}>
-      {playing ? '⏸' : '▶'}
+    <button class="transport-btn" title="Skip to start" onclick={() => seek(0)}
+      >‹</button
+    >
+    <button class="transport-btn" title="Rewind 10s" onclick={() => skipBy(-10)}
+      >‹‹</button
+    >
+    <button
+      class="transport-btn play-btn"
+      title={playing ? "Pause" : "Play"}
+      disabled={loading || !!loadError}
+      onclick={handlePlayPause}
+    >
+      {playing ? "⏸" : "▶"}
     </button>
-    <button class="transport-btn" title="Forward 10s"  onclick={() => skipBy(10)}>››</button>
-    <button class="transport-btn" title="Skip to end"  onclick={() => seek(1)}>›</button>
+    <button class="transport-btn" title="Forward 10s" onclick={() => skipBy(10)}
+      >››</button
+    >
+    <button class="transport-btn" title="Skip to end" onclick={() => seek(1)}
+      >›</button
+    >
   </div>
 
   <!-- ── Stems ── -->
@@ -355,34 +415,81 @@
       {@const muted = isMuted(stem.key)}
       {@const stemGradId = waveformGradientId(track.id, stem.key)}
       <div class="stem-row">
-        <span class="stem-label" style="color:{muted ? 'var(--fg-muted)' : stem.color}">{stem.label}</span>
-        <div class="stem-waveform-wrap" style="opacity:{loading ? 0.35 : 1}; transition:opacity 0.3s">
-          <svg class="stem-waveform" viewBox="0 0 400 28" preserveAspectRatio="none">
+        <span
+          class="stem-label"
+          style="color:{muted ? 'var(--fg-muted)' : stem.color}"
+          >{stem.label}</span
+        >
+        <div
+          class="stem-waveform-wrap"
+          style="opacity:{loading ? 0.35 : 1}; transition:opacity 0.3s"
+        >
+          <svg
+            class="stem-waveform"
+            viewBox="0 0 400 28"
+            preserveAspectRatio="none"
+          >
             <defs>
-              <linearGradient id={stemGradId}
-                              gradientUnits="userSpaceOnUse" x1="0" x2="400" y1="0" y2="0">
-                <stop offset="{playhead * 100}%" stop-color={muted ? '#2e2e2e' : stem.color} />
-                <stop offset="{playhead * 100}%" stop-color={muted ? '#2e2e2e' : '#383838'} />
+              <linearGradient
+                id={stemGradId}
+                gradientUnits="userSpaceOnUse"
+                x1="0"
+                x2="400"
+                y1="0"
+                y2="0"
+              >
+                <stop
+                  offset="{playhead * 100}%"
+                  stop-color={muted ? "#2e2e2e" : stem.color}
+                />
+                <stop
+                  offset="{playhead * 100}%"
+                  stop-color={muted ? "#2e2e2e" : "#383838"}
+                />
               </linearGradient>
             </defs>
-            {#each (waveformData[stem.key] ?? makeWaveformBars(track.id + stem.key, 120)) as h, i}
+            {#each waveformData[stem.key] ?? makeWaveformBars(track.id + stem.key, 120) as h, i}
               {@const x = i * (400 / 120)}
               {@const bh = h * 24}
-              <rect x={x} y={(28 - bh) / 2} width="2.2" height={bh} rx="0.5"
-                    fill="url(#{stemGradId})"
-                    opacity={muted ? 0.5 : 1} />
+              <rect
+                {x}
+                y={(28 - bh) / 2}
+                width="2.2"
+                height={bh}
+                rx="0.5"
+                fill="url(#{stemGradId})"
+                opacity={muted ? 0.5 : 1}
+              />
             {/each}
           </svg>
           <div class="stem-playhead" style="left:{playhead * 100}%"></div>
         </div>
-        <button class="stem-btn" class:active={state.muted && !anySoloed}
-                onclick={() => toggleMute(stem.key)} title="Mute">M</button>
-        <button class="stem-btn" class:active={state.soloed}
-                onclick={() => toggleSolo(stem.key)} title="Solo">S</button>
-        <input class="vol-slider" type="range" min="0" max="1" step="0.01"
-               value={state.volume}
-               style="accent-color:{stem.color}"
-               oninput={(e) => stemState[stem.key] = { ...state, volume: +e.target.value }} />
+        <button
+          class="stem-btn"
+          class:active={state.muted && !anySoloed}
+          onclick={() => toggleMute(stem.key)}
+          title="Mute">M</button
+        >
+        <button
+          class="stem-btn"
+          class:active={state.soloed}
+          onclick={() => toggleSolo(stem.key)}
+          title="Solo">S</button
+        >
+        <input
+          class="vol-slider"
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          value={state.volume}
+          style="accent-color:{stem.color}"
+          oninput={(e) =>
+            (stemState[stem.key] = {
+              ...state,
+              volume: +e.currentTarget.value,
+            })}
+        />
       </div>
     {/each}
   </div>
@@ -390,12 +497,14 @@
   <!-- ── Footer ── -->
   <div class="playback-footer">
     {#if exportError}
-      <span class="export-error">{exportError}
-        <button class="dismiss-btn" onclick={() => exportError = ''}>×</button>
+      <span class="export-error"
+        >{exportError}
+        <button class="dismiss-btn" onclick={() => (exportError = "")}>×</button
+        >
       </span>
     {/if}
     <button class="export-btn" onclick={exportStems} disabled={!!exportingId}>
-      {exportingId ? 'Exporting…' : '↓ Export stems'}
+      {exportingId ? "Exporting…" : "↓ Export stems"}
     </button>
   </div>
 </div>
@@ -463,7 +572,9 @@
     max-width: 260px;
   }
 
-  .header-spacer { /* balances back button */ }
+  .header-spacer {
+    flex: 1;
+  } /* balances back button */
 
   /* ── Master waveform ── */
   .master-section {

--- a/ui/lib/Playback.svelte.test.js
+++ b/ui/lib/Playback.svelte.test.js
@@ -1,23 +1,23 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, fireEvent, waitFor, cleanup } from '@testing-library/svelte'
-import Playback from './Playback.svelte'
-import { invoke } from '@tauri-apps/api/core'
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, waitFor, cleanup } from "@testing-library/svelte";
+import Playback from "./Playback.svelte";
+import { invoke } from "@tauri-apps/api/core";
 
-vi.mock('@tauri-apps/api/core', () => ({
+vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
-  convertFileSrc: vi.fn(path => `asset://${path}`),
-}))
+  convertFileSrc: vi.fn((path) => `asset://${path}`),
+}));
 
-vi.mock('@tauri-apps/plugin-dialog', () => ({
+vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(),
-}))
+}));
 
 // Minimal AudioBuffer that satisfies extractWaveform (needs getChannelData)
 function mockBuffer() {
   return {
     duration: 10,
     getChannelData: vi.fn().mockReturnValue(new Float32Array(1000)),
-  }
+  };
 }
 
 // Fresh AudioContext mock per test so spies don't bleed between tests
@@ -28,16 +28,20 @@ function makeAudioCtx() {
       connect: vi.fn(),
     }),
     createBufferSource: vi.fn().mockReturnValue({
-      buffer: null, connect: vi.fn(), start: vi.fn(), stop: vi.fn(), disconnect: vi.fn(),
+      buffer: null,
+      connect: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+      disconnect: vi.fn(),
     }),
     destination: {},
     currentTime: 0,
-    state: 'running',
+    state: "running",
     addEventListener: vi.fn(),
     close: vi.fn().mockResolvedValue(undefined),
     decodeAudioData: vi.fn().mockResolvedValue(mockBuffer()),
     resume: vi.fn().mockResolvedValue(undefined),
-  }
+  };
 }
 
 function makeTrack(id) {
@@ -45,186 +49,246 @@ function makeTrack(id) {
     id,
     title: `Track ${id}`,
     artist: null,
-    status_download: 'done',
-    status_stems: 'done',
-    status_analysis: 'done',
+    status_download: "done",
+    status_stems: "done",
+    status_analysis: "done",
     error_message: null,
     duration_ms: 10000,
-  }
+  };
 }
 
-let audioCtx
-let cancelAnimationFrameSpy
+let audioCtx;
+let cancelAnimationFrameSpy;
 
 beforeEach(() => {
-  audioCtx = makeAudioCtx()
-  vi.stubGlobal('AudioContext', vi.fn().mockReturnValue(audioCtx))
+  audioCtx = makeAudioCtx();
+  vi.stubGlobal("AudioContext", vi.fn().mockReturnValue(audioCtx));
 
-  let rafId = 0
-  vi.stubGlobal('requestAnimationFrame', vi.fn().mockImplementation(() => ++rafId))
-  cancelAnimationFrameSpy = vi.fn()
-  vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrameSpy)
+  let rafId = 0;
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    vi.fn().mockImplementation(() => ++rafId),
+  );
+  cancelAnimationFrameSpy = vi.fn();
+  vi.stubGlobal("cancelAnimationFrame", cancelAnimationFrameSpy);
 
-  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-    ok: true,
-    arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
-  }))
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
+    }),
+  );
 
   invoke.mockResolvedValue({
-    bass: '/stems/bass.wav', drums: '/stems/drums.wav',
-    vocals: '/stems/vocals.wav', other: '/stems/other.wav',
-  })
-})
+    bass: "/stems/bass.wav",
+    drums: "/stems/drums.wav",
+    vocals: "/stems/vocals.wav",
+    other: "/stems/other.wav",
+  });
+});
 
 afterEach(() => {
-  vi.unstubAllGlobals()
-  cleanup()
-})
+  vi.unstubAllGlobals();
+  cleanup();
+});
 
 // Wait until the play button is enabled (audio has finished loading)
 async function waitForAudio(container) {
   await waitFor(() => {
-    const btn = container.querySelector('.play-btn')
-    if (!btn || btn.disabled) throw new Error('audio not loaded yet')
-  })
+    const btn = container.querySelector(".play-btn");
+    if (!btn || btn.disabled) throw new Error("audio not loaded yet");
+  });
 }
 
-describe('Waveform gradient rendering', () => {
-  it('renders a linearGradient inside the master waveform SVG', async () => {
-    const { container } = render(Playback, { track: makeTrack('t1'), active: true, onBack: vi.fn() })
-    const gradient = container.querySelector('svg.waveform linearGradient')
-    expect(gradient).not.toBeNull()
-  })
+describe("Waveform gradient rendering", () => {
+  it("renders a linearGradient inside the master waveform SVG", async () => {
+    const { container } = render(Playback, {
+      track: makeTrack("t1"),
+      active: true,
+      onBack: vi.fn(),
+    });
+    const gradient = container.querySelector("svg.waveform linearGradient");
+    expect(gradient).not.toBeNull();
+  });
 
-  it('master gradient id is wf-{track.id}-master', async () => {
-    const { container } = render(Playback, { track: makeTrack('t1'), active: true, onBack: vi.fn() })
-    expect(container.querySelector('svg.waveform linearGradient').id).toBe('wf-t1-master')
-  })
+  it("master gradient id is wf-{track.id}-master", async () => {
+    const { container } = render(Playback, {
+      track: makeTrack("t1"),
+      active: true,
+      onBack: vi.fn(),
+    });
+    expect(container.querySelector("svg.waveform linearGradient").id).toBe(
+      "wf-t1-master",
+    );
+  });
 
-  it('all 120 master rects use gradient URL fill, not a hex color', async () => {
-    const { container } = render(Playback, { track: makeTrack('t1'), active: true, onBack: vi.fn() })
-    const rects = container.querySelectorAll('svg.waveform rect')
-    expect(rects.length).toBe(120)
+  it("all 120 master rects use gradient URL fill, not a hex color", async () => {
+    const { container } = render(Playback, {
+      track: makeTrack("t1"),
+      active: true,
+      onBack: vi.fn(),
+    });
+    const rects = container.querySelectorAll("svg.waveform rect");
+    expect(rects.length).toBe(120);
     for (const rect of rects) {
-      expect(rect.getAttribute('fill')).toBe('url(#wf-t1-master)')
+      expect(rect.getAttribute("fill")).toBe("url(#wf-t1-master)");
     }
-  })
+  });
 
-  it('renders a linearGradient inside each of the 4 stem waveform SVGs', async () => {
-    const { container } = render(Playback, { track: makeTrack('t1'), active: true, onBack: vi.fn() })
-    const svgs = container.querySelectorAll('svg.stem-waveform')
-    expect(svgs.length).toBe(4)
+  it("renders a linearGradient inside each of the 4 stem waveform SVGs", async () => {
+    const { container } = render(Playback, {
+      track: makeTrack("t1"),
+      active: true,
+      onBack: vi.fn(),
+    });
+    const svgs = container.querySelectorAll("svg.stem-waveform");
+    expect(svgs.length).toBe(4);
     for (const svg of svgs) {
-      expect(svg.querySelector('linearGradient')).not.toBeNull()
+      expect(svg.querySelector("linearGradient")).not.toBeNull();
     }
-  })
+  });
 
-  it('stem gradient IDs match expected keys', async () => {
-    const { container } = render(Playback, { track: makeTrack('t1'), active: true, onBack: vi.fn() })
-    const ids = Array.from(container.querySelectorAll('svg.stem-waveform linearGradient')).map(g => g.id)
-    for (const key of ['vocals', 'drums', 'bass', 'other']) {
-      expect(ids).toContain(`wf-t1-${key}`)
+  it("stem gradient IDs match expected keys", async () => {
+    const { container } = render(Playback, {
+      track: makeTrack("t1"),
+      active: true,
+      onBack: vi.fn(),
+    });
+    const ids = Array.from(
+      container.querySelectorAll("svg.stem-waveform linearGradient"),
+    ).map((g) => g.id);
+    for (const key of ["vocals", "drums", "bass", "other"]) {
+      expect(ids).toContain(`wf-t1-${key}`);
     }
-  })
+  });
 
-  it('all 120 rects in each stem waveform use gradient URL fill', async () => {
-    const { container } = render(Playback, { track: makeTrack('t1'), active: true, onBack: vi.fn() })
-    for (const svg of container.querySelectorAll('svg.stem-waveform')) {
-      const rects = svg.querySelectorAll('rect')
-      expect(rects.length).toBe(120)
+  it("all 120 rects in each stem waveform use gradient URL fill", async () => {
+    const { container } = render(Playback, {
+      track: makeTrack("t1"),
+      active: true,
+      onBack: vi.fn(),
+    });
+    for (const svg of container.querySelectorAll("svg.stem-waveform")) {
+      const rects = svg.querySelectorAll("rect");
+      expect(rects.length).toBe(120);
       for (const rect of rects) {
-        expect(rect.getAttribute('fill')).toMatch(/^url\(#wf-/)
+        expect(rect.getAttribute("fill")).toMatch(/^url\(#wf-/);
       }
     }
-  })
+  });
 
-  it('master gradient has exactly 2 stops', async () => {
-    const { container } = render(Playback, { track: makeTrack('t1'), active: true, onBack: vi.fn() })
-    const stops = container.querySelectorAll('svg.waveform linearGradient stop')
-    expect(stops.length).toBe(2)
-  })
+  it("master gradient has exactly 2 stops", async () => {
+    const { container } = render(Playback, {
+      track: makeTrack("t1"),
+      active: true,
+      onBack: vi.fn(),
+    });
+    const stops = container.querySelectorAll(
+      "svg.waveform linearGradient stop",
+    );
+    expect(stops.length).toBe(2);
+  });
 
-  it('master gradient stops are both at 0% on initial render (playhead=0)', async () => {
-    const { container } = render(Playback, { track: makeTrack('t1'), active: true, onBack: vi.fn() })
-    const stops = container.querySelectorAll('svg.waveform linearGradient stop')
-    expect(stops[0].getAttribute('offset')).toBe('0%')
-    expect(stops[1].getAttribute('offset')).toBe('0%')
-  })
+  it("master gradient stops are both at 0% on initial render (playhead=0)", async () => {
+    const { container } = render(Playback, {
+      track: makeTrack("t1"),
+      active: true,
+      onBack: vi.fn(),
+    });
+    const stops = container.querySelectorAll(
+      "svg.waveform linearGradient stop",
+    );
+    expect(stops[0].getAttribute("offset")).toBe("0%");
+    expect(stops[1].getAttribute("offset")).toBe("0%");
+  });
 
-  it('updates gradient stop offsets when playhead advances', async () => {
-    let capturedTick
-    vi.mocked(requestAnimationFrame).mockImplementationOnce(cb => {
-      capturedTick = cb
-      return 1
-    })
+  it("updates gradient stop offsets when playhead advances", async () => {
+    let capturedTick;
+    vi.mocked(requestAnimationFrame).mockImplementationOnce((cb) => {
+      capturedTick = cb;
+      return 1;
+    });
 
-    const { container } = render(Playback, { track: makeTrack('t1'), active: true, onBack: vi.fn() })
-    await waitForAudio(container)
+    const { container } = render(Playback, {
+      track: makeTrack("t1"),
+      active: true,
+      onBack: vi.fn(),
+    });
+    await waitForAudio(container);
 
-    await fireEvent.click(container.querySelector('.play-btn'))
-    expect(capturedTick).toBeDefined()
+    await fireEvent.click(container.querySelector(".play-btn"));
+    expect(capturedTick).toBeDefined();
 
     // Advance audio time to half the 10s track (duration comes from mockBuffer.duration = 10)
-    audioCtx.currentTime = 5
-    capturedTick()
+    audioCtx.currentTime = 5;
+    capturedTick();
 
     await waitFor(() => {
-      const stops = container.querySelectorAll('svg.waveform linearGradient stop')
-      expect(stops[0].getAttribute('offset')).toBe('50%')
-      expect(stops[1].getAttribute('offset')).toBe('50%')
-    })
-  })
+      const stops = container.querySelectorAll(
+        "svg.waveform linearGradient stop",
+      );
+      expect(stops[0].getAttribute("offset")).toBe("50%");
+      expect(stops[1].getAttribute("offset")).toBe("50%");
+    });
+  });
 
-  it('muted stem gradient uses muted color for both stops', async () => {
-    const { container } = render(Playback, { track: makeTrack('t1'), active: true, onBack: vi.fn() })
+  it("muted stem gradient uses muted color for both stops", async () => {
+    const { container } = render(Playback, {
+      track: makeTrack("t1"),
+      active: true,
+      onBack: vi.fn(),
+    });
 
     // Mute the vocals stem (first mute button)
-    await fireEvent.click(container.querySelectorAll('[title="Mute"]')[0])
+    await fireEvent.click(container.querySelectorAll('[title="Mute"]')[0]);
 
     await waitFor(() => {
-      const gradient = container.querySelector('linearGradient[id="wf-t1-vocals"]')
-      const stops = gradient.querySelectorAll('stop')
-      expect(stops[0].getAttribute('stop-color')).toBe('#2e2e2e')
-      expect(stops[1].getAttribute('stop-color')).toBe('#2e2e2e')
-    })
-  })
-})
+      const gradient = container.querySelector(
+        'linearGradient[id="wf-t1-vocals"]',
+      );
+      const stops = gradient.querySelectorAll("stop");
+      expect(stops[0].getAttribute("stop-color")).toBe("#2e2e2e");
+      expect(stops[1].getAttribute("stop-color")).toBe("#2e2e2e");
+    });
+  });
+});
 
-describe('Playback resource management', () => {
-  it('cancels the existing RAF loop when switching to a different track', async () => {
+describe("Playback resource management", () => {
+  it("cancels the existing RAF loop when switching to a different track", async () => {
     const { container, rerender } = render(Playback, {
-      track: makeTrack('a'),
+      track: makeTrack("a"),
       active: true,
       onBack: vi.fn(),
-    })
+    });
 
-    await waitForAudio(container)
+    await waitForAudio(container);
 
     // Start playback — schedTick() → requestAnimationFrame, setting rafId
-    await fireEvent.click(container.querySelector('.play-btn'))
-    expect(requestAnimationFrame).toHaveBeenCalled()
+    await fireEvent.click(container.querySelector(".play-btn"));
+    expect(requestAnimationFrame).toHaveBeenCalled();
 
     // Reset spy so we only capture cancellations from the track switch
-    cancelAnimationFrameSpy.mockClear()
+    cancelAnimationFrameSpy.mockClear();
 
     // Switch to a different track — loadAudio() should call cancelTick()
-    await rerender({ track: makeTrack('b'), active: true, onBack: vi.fn() })
+    await rerender({ track: makeTrack("b"), active: true, onBack: vi.fn() });
 
-    await waitFor(() => expect(cancelAnimationFrameSpy).toHaveBeenCalled())
-  })
+    await waitFor(() => expect(cancelAnimationFrameSpy).toHaveBeenCalled());
+  });
 
-  it('closes the AudioContext when the component unmounts', async () => {
+  it("closes the AudioContext when the component unmounts", async () => {
     const { container, unmount } = render(Playback, {
-      track: makeTrack('a'),
+      track: makeTrack("a"),
       active: true,
       onBack: vi.fn(),
-    })
+    });
 
     // Wait for audio to load so AudioContext is created
-    await waitForAudio(container)
+    await waitForAudio(container);
 
-    unmount()
+    unmount();
 
-    expect(audioCtx.close).toHaveBeenCalled()
-  })
-})
+    expect(audioCtx.close).toHaveBeenCalled();
+  });
+});

--- a/ui/lib/Setup.svelte
+++ b/ui/lib/Setup.svelte
@@ -1,75 +1,77 @@
 <script>
-  import { invoke } from '@tauri-apps/api/core'
-  import { listen } from '@tauri-apps/api/event'
-  import { onDestroy } from 'svelte'
+  import { invoke } from "@tauri-apps/api/core";
+  import { listen } from "@tauri-apps/api/event";
+  import { onDestroy } from "svelte";
 
-  let { onReady } = $props()
+  let { onReady } = $props();
 
-  let downloading = $state(false)
-  let error = $state(null)
-  let progress = $state(null) // { downloaded_mb, total_mb, percent }
+  let downloading = $state(false);
+  let error = $state(null);
+  let progress = $state(null); // { downloaded_mb, total_mb, percent }
 
-  let unlisten
-  onDestroy(() => unlisten?.())
+  let unlisten;
+  onDestroy(() => unlisten?.());
 
   async function startDownload() {
-    if (downloading) return
-    unlisten?.()
-    downloading = true
-    error = null
-    progress = null
+    if (downloading) return;
+    unlisten?.();
+    downloading = true;
+    error = null;
+    progress = null;
 
-    unlisten = await listen('setup:progress', (e) => {
-      progress = e.payload
-    })
+    unlisten = await listen("setup:progress", (e) => {
+      progress = e.payload;
+    });
 
     try {
-      await invoke('download_demucs')
-      onReady()
+      await invoke("download_demucs");
+      onReady();
     } catch (e) {
-      error = String(e)
-      downloading = false
+      error = String(e);
+      downloading = false;
     }
   }
 </script>
 
 <div class="card">
-    <h2>One-time setup</h2>
-    <p class="description">
-      Before you can split your first track, Wavesplit needs to download the audio separation engine.
-      This only happens once. After that, everything works offline.
-    </p>
+  <h2>One-time setup</h2>
+  <p class="description">
+    Before you can split your first track, Wavesplit needs to download the audio
+    separation engine. This only happens once. After that, everything works
+    offline.
+  </p>
 
-    {#if error}
-      <p class="error">{error}</p>
-    {/if}
+  {#if error}
+    <p class="error">{error}</p>
+  {/if}
 
-    {#if downloading && progress}
-      <div class="progress-wrap">
-        <div class="progress-bar">
-          <div
-            class="progress-fill"
-            style="width: {progress.percent ?? 0}%"
-          ></div>
-        </div>
-        <p class="progress-label">
-          {#if progress.total_mb}
-            {progress.downloaded_mb.toFixed(0)} / {progress.total_mb.toFixed(0)} MB
-            ({progress.percent}%)
-          {:else}
-            {progress.downloaded_mb.toFixed(0)} MB downloaded…
-          {/if}
-        </p>
+  {#if downloading && progress}
+    <div class="progress-wrap">
+      <div class="progress-bar">
+        <div
+          class="progress-fill"
+          style="width: {progress.percent ?? 0}%"
+        ></div>
       </div>
-    {:else if downloading}
-      <p class="progress-label">Connecting…</p>
-    {:else}
-      <button onclick={startDownload}>Download</button>
-    {/if}
+      <p class="progress-label">
+        {#if progress.total_mb}
+          {progress.downloaded_mb.toFixed(0)} / {progress.total_mb.toFixed(0)} MB
+          ({progress.percent}%)
+        {:else}
+          {progress.downloaded_mb.toFixed(0)} MB downloaded…
+        {/if}
+      </p>
+    </div>
+  {:else if downloading}
+    <p class="progress-label">Connecting…</p>
+  {:else}
+    <button onclick={startDownload}>Download</button>
+  {/if}
 
-    <p class="note">
-      Make sure you're on Wi-Fi. The first time you split a track, an additional ~80 MB will be fetched automatically.
-    </p>
+  <p class="note">
+    Make sure you're on Wi-Fi. The first time you split a track, an additional
+    ~80 MB will be fetched automatically.
+  </p>
 </div>
 
 <style>

--- a/ui/lib/Setup.svelte.test.js
+++ b/ui/lib/Setup.svelte.test.js
@@ -1,73 +1,73 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, fireEvent, waitFor, cleanup } from '@testing-library/svelte'
-import Setup from './Setup.svelte'
-import { invoke } from '@tauri-apps/api/core'
-import { listen } from '@tauri-apps/api/event'
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, waitFor, cleanup } from "@testing-library/svelte";
+import Setup from "./Setup.svelte";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 
-vi.mock('@tauri-apps/api/core', () => ({
+vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
-}))
+}));
 
-vi.mock('@tauri-apps/api/event', () => ({
+vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn(),
-}))
+}));
 
 beforeEach(() => {
-  vi.resetAllMocks()
-})
+  vi.resetAllMocks();
+});
 
 afterEach(() => {
-  cleanup()
-})
+  cleanup();
+});
 
-describe('Setup concurrency guard', () => {
-  it('registers only one event listener when startDownload is triggered twice in quick succession', async () => {
+describe("Setup concurrency guard", () => {
+  it("registers only one event listener when startDownload is triggered twice in quick succession", async () => {
     // listen() never resolves, so downloading stays true for the duration of the test
-    listen.mockReturnValue(new Promise(() => {}))
+    listen.mockReturnValue(new Promise(() => {}));
 
-    const { container } = render(Setup, { onReady: vi.fn() })
-    const btn = container.querySelector('button')
+    const { container } = render(Setup, { onReady: vi.fn() });
+    const btn = container.querySelector("button");
 
     // Fire two clicks without awaiting — the handler for the first click runs
     // synchronously up to `await listen()`, setting downloading=true before the
     // second click executes. The guard `if (downloading) return` must catch it.
-    fireEvent.click(btn)
-    fireEvent.click(btn)
+    fireEvent.click(btn);
+    fireEvent.click(btn);
 
     // Flush microtasks so any erroneous second listen() call would have run
-    await Promise.resolve()
+    await Promise.resolve();
 
-    expect(listen).toHaveBeenCalledTimes(1)
-  })
-})
+    expect(listen).toHaveBeenCalledTimes(1);
+  });
+});
 
-describe('Setup listener cleanup on retry', () => {
-  it('calls the previous unlisten before registering a new listener on retry', async () => {
-    const unlisten1 = vi.fn()
-    const unlisten2 = vi.fn()
+describe("Setup listener cleanup on retry", () => {
+  it("calls the previous unlisten before registering a new listener on retry", async () => {
+    const unlisten1 = vi.fn();
+    const unlisten2 = vi.fn();
 
-    listen
-      .mockResolvedValueOnce(unlisten1)
-      .mockResolvedValueOnce(unlisten2)
+    listen.mockResolvedValueOnce(unlisten1).mockResolvedValueOnce(unlisten2);
 
     // First attempt fails so the user can retry
-    invoke.mockRejectedValueOnce(new Error('network error'))
-    invoke.mockResolvedValueOnce(undefined)
+    invoke.mockRejectedValueOnce(new Error("network error"));
+    invoke.mockResolvedValueOnce(undefined);
 
-    const { container } = render(Setup, { onReady: vi.fn() })
+    const { container } = render(Setup, { onReady: vi.fn() });
 
     // First download attempt — invoke rejects → error shown, downloading reset to false
-    await fireEvent.click(container.querySelector('button'))
-    await waitFor(() => expect(container.querySelector('.error')).not.toBeNull())
+    await fireEvent.click(container.querySelector("button"));
+    await waitFor(() =>
+      expect(container.querySelector(".error")).not.toBeNull(),
+    );
 
     // At this point unlisten1 has been registered but not yet called
-    expect(unlisten1).not.toHaveBeenCalled()
+    expect(unlisten1).not.toHaveBeenCalled();
 
     // Retry — startDownload() should call unlisten1() before registering the new listener
-    await fireEvent.click(container.querySelector('button'))
-    await waitFor(() => expect(listen).toHaveBeenCalledTimes(2))
+    await fireEvent.click(container.querySelector("button"));
+    await waitFor(() => expect(listen).toHaveBeenCalledTimes(2));
 
-    expect(unlisten1).toHaveBeenCalledTimes(1)
-    expect(listen).toHaveBeenCalledTimes(2)
-  })
-})
+    expect(unlisten1).toHaveBeenCalledTimes(1);
+    expect(listen).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/lib/TrackList.svelte
+++ b/ui/lib/TrackList.svelte
@@ -1,158 +1,192 @@
 <script>
-  import { invoke } from '@tauri-apps/api/core'
-  import { listen } from '@tauri-apps/api/event'
-  import { open as openDialog, confirm } from '@tauri-apps/plugin-dialog'
+  import { invoke } from "@tauri-apps/api/core";
+  import { listen } from "@tauri-apps/api/event";
+  import { open as openDialog, confirm } from "@tauri-apps/plugin-dialog";
 
-  import { onMount, onDestroy } from 'svelte'
-  import { fuzzy, SORT_FNS, isReady, hasError, statusLabel, progressPct } from './tracklist.helpers.js'
+  import { onMount, onDestroy } from "svelte";
+  import {
+    fuzzy,
+    SORT_FNS,
+    isReady,
+    hasError,
+    statusLabel,
+    progressPct,
+  } from "./tracklist.helpers.js";
 
-  let { tracks = $bindable([]), refresh = $bindable(null), onPlay } = $props()
+  let { tracks = $bindable([]), refresh = $bindable(null), onPlay } = $props();
 
   // pipeline events keyed by track id: { stage, status, message }
-  let progress = $state({})
+  let progress = $state({});
 
-  let filterQuery = $state('')
-  let sortKey = $state('newest')
+  let filterQuery = $state("");
+  let sortKey = $state("newest");
 
   function matchesFilter(track) {
-    if (!filterQuery) return true
-    return fuzzy(filterQuery, track.title) || fuzzy(filterQuery, track.artist ?? '')
+    if (!filterQuery) return true;
+    return (
+      fuzzy(filterQuery, track.title) || fuzzy(filterQuery, track.artist ?? "")
+    );
   }
 
   let displayTracks = $derived(
-    tracks.filter(matchesFilter).sort(SORT_FNS[sortKey])
-  )
+    tracks.filter(matchesFilter).sort(SORT_FNS[sortKey]),
+  );
 
-  let unlisten
+  let unlisten;
 
   onMount(async () => {
-    refresh = refreshTracks
-    unlisten = await listen('pipeline', (event) => {
-      const { track_id, stage, status, message } = event.payload
+    refresh = refreshTracks;
+    unlisten = await listen("pipeline", (event) => {
+      const { track_id, stage, status, message } = event.payload;
       progress = {
         ...progress,
         [track_id]: { stage, status, message },
-      }
+      };
       // Refresh from DB whenever any stage finishes or errors
-      if (status === 'done' || status === 'error') {
-        refreshTracks()
+      if (status === "done" || status === "error") {
+        refreshTracks();
       }
-    })
-    await refreshTracks()
-  })
+    });
+    await refreshTracks();
+  });
 
-  onDestroy(() => unlisten?.())
+  onDestroy(() => unlisten?.());
 
-  const PENDING_ID = '__pending__'
+  const PENDING_ID = "__pending__";
 
   async function refreshTracks() {
-    tracks = await invoke('list_tracks')
+    tracks = await invoke("list_tracks");
   }
 
   // Inline editing: editingId = track id currently being edited
-  let editingId = $state(null)
-  let editTitle = $state('')
-  let editArtist = $state('')
+  let editingId = $state(null);
+  let editTitle = $state("");
+  let editArtist = $state("");
 
   function startEdit(track) {
-    editingId = track.id
-    editTitle = track.title
-    editArtist = track.artist ?? ''
+    editingId = track.id;
+    editTitle = track.title;
+    editArtist = track.artist ?? "";
   }
 
   async function commitEdit(track) {
-    if (editingId !== track.id) return
-    editingId = null
-    const trimmedTitle = editTitle.trim() || track.title
-    const trimmedArtist = editArtist.trim() || null
-    if (trimmedTitle === track.title && trimmedArtist === (track.artist ?? null)) return
-    editError = ''
+    if (editingId !== track.id) return;
+    editingId = null;
+    const trimmedTitle = editTitle.trim() || track.title;
+    const trimmedArtist = editArtist.trim() || null;
+    if (
+      trimmedTitle === track.title &&
+      trimmedArtist === (track.artist ?? null)
+    )
+      return;
+    editError = "";
     try {
-      await invoke('update_track_meta', { id: track.id, title: trimmedTitle, artist: trimmedArtist })
-      await refreshTracks()
+      await invoke("update_track_meta", {
+        id: track.id,
+        title: trimmedTitle,
+        artist: trimmedArtist,
+      });
+      await refreshTracks();
     } catch (e) {
-      editError = String(e)
-      await refreshTracks()
+      editError = String(e);
+      await refreshTracks();
     }
   }
 
   function onEditKeydown(e, track) {
-    if (e.key === 'Enter') { e.target.blur() }
-    if (e.key === 'Escape') { editingId = null }
-  }
-
-  let editError = $state('')
-
-  let exportingId = $state(null)
-  let exportError = $state('')
-
-  async function exportStems(track) {
-    const dest = await openDialog({ directory: true, title: 'Export stems to…' })
-    if (!dest) return
-    exportingId = track.id
-    exportError = ''
-    try {
-      await invoke('export_stems', { trackId: track.id, destDir: dest })
-      await refreshTracks()
-    } catch (e) {
-      exportError = String(e)
-    } finally {
-      exportingId = null
+    if (e.key === "Enter") {
+      e.target.blur();
+    }
+    if (e.key === "Escape") {
+      editingId = null;
     }
   }
 
-  let deleteError = $state('')
+  let editError = $state("");
 
-  let retryingId = $state(null)
-  let retryError = $state('')
+  let exportingId = $state(null);
+  let exportError = $state("");
+
+  async function exportStems(track) {
+    const dest = await openDialog({
+      directory: true,
+      title: "Export stems to…",
+    });
+    if (!dest) return;
+    exportingId = track.id;
+    exportError = "";
+    try {
+      await invoke("export_stems", { trackId: track.id, destDir: dest });
+      await refreshTracks();
+    } catch (e) {
+      exportError = String(e);
+    } finally {
+      exportingId = null;
+    }
+  }
+
+  let deleteError = $state("");
+
+  let retryingId = $state(null);
+  let retryError = $state("");
 
   async function retryTrack(track) {
-    retryingId = track.id
-    retryError = ''
+    retryingId = track.id;
+    retryError = "";
     try {
-      await invoke('retry_track', { id: track.id })
-      await refreshTracks()
+      await invoke("retry_track", { id: track.id });
+      await refreshTracks();
     } catch (e) {
-      retryError = String(e)
+      retryError = String(e);
     } finally {
-      retryingId = null
+      retryingId = null;
     }
   }
 
   async function deleteTrack(track) {
     const ok = await confirm(
       `"${track.title}" and all its stems will be permanently deleted.`,
-      { title: 'Delete track?', kind: 'warning', okLabel: 'Delete', cancelLabel: 'Cancel' }
-    )
-    if (!ok) return
-    deleteError = ''
+      {
+        title: "Delete track?",
+        kind: "warning",
+        okLabel: "Delete",
+        cancelLabel: "Cancel",
+      },
+    );
+    if (!ok) return;
+    deleteError = "";
     try {
-      await invoke('delete_track', { id: track.id })
-      tracks = tracks.filter((t) => t.id !== track.id)
-      const { [track.id]: _, ...rest } = progress
-      progress = rest
+      await invoke("delete_track", { id: track.id });
+      tracks = tracks.filter((t) => t.id !== track.id);
+      progress = Object.fromEntries(
+        Object.entries(progress).filter(([k]) => k !== String(track.id)),
+      );
     } catch (e) {
-      deleteError = String(e)
+      deleteError = String(e);
     }
   }
 
   async function openFolder(path) {
     try {
-      await invoke('open_folder', { path })
+      await invoke("open_folder", { path });
     } catch (e) {
-      deleteError = String(e)
+      deleteError = String(e);
     }
   }
 
   function isProcessing(track) {
-    return !isReady(track) && !hasError(track, progress)
+    return !isReady(track) && !hasError(track, progress);
   }
 </script>
 
 <div class="track-list">
   {#if tracks.length > 0}
     <div class="toolbar">
-      <input class="filter-input" placeholder="Search" bind:value={filterQuery} />
+      <input
+        class="filter-input"
+        placeholder="Search"
+        bind:value={filterQuery}
+      />
       <select class="sort-select" bind:value={sortKey}>
         <option value="newest">Newest</option>
         <option value="oldest">Oldest</option>
@@ -163,99 +197,181 @@
   {/if}
 
   <div class="tracks-scroll">
-  {#if editError}
-    <p class="export-error">{editError} <button class="dismiss-error" onclick={() => editError = ''}>×</button></p>
-  {/if}
+    {#if editError}
+      <p class="export-error">
+        {editError}
+        <button class="dismiss-error" onclick={() => (editError = "")}>×</button
+        >
+      </p>
+    {/if}
 
-  {#if deleteError}
-    <p class="export-error">{deleteError} <button class="dismiss-error" onclick={() => deleteError = ''}>×</button></p>
-  {/if}
+    {#if deleteError}
+      <p class="export-error">
+        {deleteError}
+        <button class="dismiss-error" onclick={() => (deleteError = "")}
+          >×</button
+        >
+      </p>
+    {/if}
 
-  {#if exportError}
-    <p class="export-error">{exportError} <button class="dismiss-error" onclick={() => exportError = ''}>×</button></p>
-  {/if}
+    {#if exportError}
+      <p class="export-error">
+        {exportError}
+        <button class="dismiss-error" onclick={() => (exportError = "")}
+          >×</button
+        >
+      </p>
+    {/if}
 
-  {#if retryError}
-    <p class="export-error">{retryError} <button class="dismiss-error" onclick={() => retryError = ''}>×</button></p>
-  {/if}
+    {#if retryError}
+      <p class="export-error">
+        {retryError}
+        <button class="dismiss-error" onclick={() => (retryError = "")}
+          >×</button
+        >
+      </p>
+    {/if}
 
-  {#if tracks.length === 0}
-    <p class="empty">No tracks yet. Add a YouTube URL or open a local file.</p>
-  {/if}
+    {#if tracks.length === 0}
+      <p class="empty">
+        No tracks yet. Add a YouTube URL or open a local file.
+      </p>
+    {/if}
 
-  {#each displayTracks as track (track.id)}
-    <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-    <div
-      class="track"
-      class:ready={isReady(track)}
-      class:error={hasError(track, progress)}
-      class:pending={track.id === PENDING_ID}
-      class:playable={isReady(track) && !!onPlay}
-      role={isReady(track) && onPlay ? 'button' : undefined}
-      tabindex={isReady(track) && onPlay ? 0 : undefined}
-      onclick={() => { if (onPlay && isReady(track) && editingId !== track.id) onPlay(track) }}
-    >
-      <div class="track-info">
-        {#if track.id === PENDING_ID}
-          <span class="title">{track.title}</span>
-          <span class="status processing">Adding…</span>
-        {:else if editingId === track.id}
-          <input
-            class="edit-input title-input"
-            bind:value={editTitle}
-            onblur={() => commitEdit(track)}
-            onkeydown={(e) => onEditKeydown(e, track)}
-          />
-          <input
-            class="edit-input artist-input"
-            placeholder="Artist"
-            bind:value={editArtist}
-            onblur={() => commitEdit(track)}
-            onkeydown={(e) => onEditKeydown(e, track)}
-          />
-        {:else}
-          <span class="title" onclick={(e) => { e.stopPropagation(); startEdit(track) }} onkeydown={(e) => { e.stopPropagation(); e.key === 'Enter' && startEdit(track) }} role="button" tabindex="0">
-            {track.title}
-          </span>
-          <span class="artist" onclick={(e) => { e.stopPropagation(); startEdit(track) }} onkeydown={(e) => { e.stopPropagation(); e.key === 'Enter' && startEdit(track) }} role="button" tabindex="0">
-            {track.artist ?? '—'}
-          </span>
-        {/if}
-        {#if track.id !== PENDING_ID}
-          <span class="status" class:processing={isProcessing(track)} class:ready={isReady(track)}>
-            {statusLabel(track, progress)}
-          </span>
-          {#if isProcessing(track)}
-            <div class="progress-bar">
-              <div class="progress-fill" style="width: {progressPct(track, progress)}%"></div>
-            </div>
+    {#each displayTracks as track (track.id)}
+      <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+      <div
+        class="track"
+        class:ready={isReady(track)}
+        class:error={hasError(track, progress)}
+        class:pending={track.id === PENDING_ID}
+        class:playable={isReady(track) && !!onPlay}
+        role={isReady(track) && onPlay ? "button" : undefined}
+        tabindex={isReady(track) && onPlay ? 0 : undefined}
+        onclick={() => {
+          if (onPlay && isReady(track) && editingId !== track.id) onPlay(track);
+        }}
+      >
+        <div class="track-info">
+          {#if track.id === PENDING_ID}
+            <span class="title">{track.title}</span>
+            <span class="status processing">Adding…</span>
+          {:else if editingId === track.id}
+            <input
+              class="edit-input title-input"
+              bind:value={editTitle}
+              onblur={() => commitEdit(track)}
+              onkeydown={(e) => onEditKeydown(e, track)}
+            />
+            <input
+              class="edit-input artist-input"
+              placeholder="Artist"
+              bind:value={editArtist}
+              onblur={() => commitEdit(track)}
+              onkeydown={(e) => onEditKeydown(e, track)}
+            />
+          {:else}
+            <span
+              class="title"
+              onclick={(e) => {
+                e.stopPropagation();
+                startEdit(track);
+              }}
+              onkeydown={(e) => {
+                e.stopPropagation();
+                e.key === "Enter" && startEdit(track);
+              }}
+              role="button"
+              tabindex="0"
+            >
+              {track.title}
+            </span>
+            <span
+              class="artist"
+              onclick={(e) => {
+                e.stopPropagation();
+                startEdit(track);
+              }}
+              onkeydown={(e) => {
+                e.stopPropagation();
+                e.key === "Enter" && startEdit(track);
+              }}
+              role="button"
+              tabindex="0"
+            >
+              {track.artist ?? "—"}
+            </span>
           {/if}
-        {/if}
-      </div>
-      <div class="track-actions">
-        {#if track.id === PENDING_ID}
-          <span class="spinner" aria-label="Adding track"></span>
-        {:else}
-          {#if isReady(track)}
-            {#if track.export_path}
-              <button class="open-btn" onclick={(e) => { e.stopPropagation(); openFolder(track.export_path) }} title={track.export_path}>
-                Open folder
+          {#if track.id !== PENDING_ID}
+            <span
+              class="status"
+              class:processing={isProcessing(track)}
+              class:ready={isReady(track)}
+            >
+              {statusLabel(track, progress)}
+            </span>
+            {#if isProcessing(track)}
+              <div class="progress-bar">
+                <div
+                  class="progress-fill"
+                  style="width: {progressPct(track, progress)}%"
+                ></div>
+              </div>
+            {/if}
+          {/if}
+        </div>
+        <div class="track-actions">
+          {#if track.id === PENDING_ID}
+            <span class="spinner" aria-label="Adding track"></span>
+          {:else}
+            {#if isReady(track)}
+              {#if track.export_path}
+                <button
+                  class="open-btn"
+                  onclick={(e) => {
+                    e.stopPropagation();
+                    openFolder(track.export_path);
+                  }}
+                  title={track.export_path}
+                >
+                  Open folder
+                </button>
+              {/if}
+              <button
+                class="export-btn"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  exportStems(track);
+                }}
+                disabled={exportingId === track.id}
+              >
+                {exportingId === track.id ? "Exporting…" : "↓ Export stems"}
               </button>
             {/if}
-            <button class="export-btn" onclick={(e) => { e.stopPropagation(); exportStems(track) }} disabled={exportingId === track.id}>
-              {exportingId === track.id ? 'Exporting…' : '↓ Export stems'}
-            </button>
+            {#if hasError(track, progress)}
+              <button
+                class="retry-btn"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  retryTrack(track);
+                }}
+                disabled={retryingId === track.id}
+              >
+                {retryingId === track.id ? "Retrying…" : "↺ Retry"}
+              </button>
+            {/if}
+            <button
+              class="delete-btn"
+              onclick={(e) => {
+                e.stopPropagation();
+                deleteTrack(track);
+              }}
+              title="Delete track">✕</button
+            >
           {/if}
-          {#if hasError(track, progress)}
-            <button class="retry-btn" onclick={(e) => { e.stopPropagation(); retryTrack(track) }} disabled={retryingId === track.id}>
-              {retryingId === track.id ? 'Retrying…' : '↺ Retry'}
-            </button>
-          {/if}
-          <button class="delete-btn" onclick={(e) => { e.stopPropagation(); deleteTrack(track) }} title="Delete track">✕</button>
-        {/if}
+        </div>
       </div>
-    </div>
-  {/each}
+    {/each}
   </div>
 </div>
 
@@ -540,6 +656,8 @@
   }
 
   @keyframes spin {
-    to { transform: rotate(360deg); }
+    to {
+      transform: rotate(360deg);
+    }
   }
 </style>

--- a/ui/lib/TrackList.svelte.test.js
+++ b/ui/lib/TrackList.svelte.test.js
@@ -1,56 +1,56 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, fireEvent } from '@testing-library/svelte'
-import { flushSync } from 'svelte'
-import TrackList from './TrackList.svelte'
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { flushSync } from "svelte";
+import TrackList from "./TrackList.svelte";
 
-vi.mock('@tauri-apps/api/core', () => ({
+vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue([]),
-}))
+}));
 
-vi.mock('@tauri-apps/api/event', () => ({
+vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn().mockResolvedValue(() => {}),
-}))
+}));
 
-vi.mock('@tauri-apps/plugin-dialog', () => ({
+vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(),
   confirm: vi.fn(),
-}))
+}));
 
 const readyTrack = {
-  id: 'track-1',
-  title: 'Test Track',
-  artist: 'Test Artist',
+  id: "track-1",
+  title: "Test Track",
+  artist: "Test Artist",
   sort_order: 1,
-  status_download: 'done',
-  status_stems: 'done',
-  status_analysis: 'done',
+  status_download: "done",
+  status_stems: "done",
+  status_analysis: "done",
   error_message: null,
   export_path: null,
   duration_ms: 180000,
-}
+};
 
-describe('TrackList keyboard play', () => {
-  let onPlay
+describe("TrackList keyboard play", () => {
+  let onPlay;
 
   beforeEach(() => {
-    onPlay = vi.fn()
-  })
+    onPlay = vi.fn();
+  });
 
-  it('Enter in a title edit input does not trigger onPlay', async () => {
-    const { container } = render(TrackList, { tracks: [readyTrack], onPlay })
+  it("Enter in a title edit input does not trigger onPlay", async () => {
+    const { container } = render(TrackList, { tracks: [readyTrack], onPlay });
 
     // Open edit mode by clicking the title span (flushSync forces Svelte's DOM update)
-    const titleEl = container.querySelector('.title')
-    fireEvent.click(titleEl)
-    flushSync()
+    const titleEl = container.querySelector(".title");
+    fireEvent.click(titleEl);
+    flushSync();
 
     // The title input should now be visible
-    const input = container.querySelector('.title-input')
-    expect(input).not.toBeNull()
+    const input = container.querySelector(".title-input");
+    expect(input).not.toBeNull();
 
     // Press Enter — should commit the edit, not play the track
-    await fireEvent.keyDown(input, { key: 'Enter' })
+    await fireEvent.keyDown(input, { key: "Enter" });
 
-    expect(onPlay).not.toHaveBeenCalled()
-  })
-})
+    expect(onPlay).not.toHaveBeenCalled();
+  });
+});

--- a/ui/lib/playback.helpers.js
+++ b/ui/lib/playback.helpers.js
@@ -1,55 +1,55 @@
 export function formatTime(s) {
-  if (!s && s !== 0) return '--:--'
-  s = Math.floor(s)
-  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`
+  if (!s && s !== 0) return "--:--";
+  s = Math.floor(s);
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
 }
 
 export function hashStr(str) {
-  let h = 0
-  for (const c of str) h = (Math.imul(31, h) + c.charCodeAt(0)) | 0
-  return h >>> 0
+  let h = 0;
+  for (const c of str) h = (Math.imul(31, h) + c.charCodeAt(0)) | 0;
+  return h >>> 0;
 }
 
 export function makeWaveformBars(seed, count) {
-  let s = hashStr(seed)
+  let s = hashStr(seed);
   return Array.from({ length: count }, () => {
-    s = (Math.imul(s, 1664525) + 1013904223) >>> 0
-    return 0.12 + (s / 0xFFFFFFFF) * 0.88
-  })
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+    return 0.12 + (s / 0xffffffff) * 0.88;
+  });
 }
 
 export function extractWaveform(audioBuffer, numPoints) {
-  const channel = audioBuffer.getChannelData(0)
-  const blockSize = Math.floor(channel.length / numPoints)
-  const result = new Array(numPoints)
+  const channel = audioBuffer.getChannelData(0);
+  const blockSize = Math.floor(channel.length / numPoints);
+  const result = new Array(numPoints);
   for (let i = 0; i < numPoints; i++) {
-    const start = i * blockSize
-    let sum = 0
+    const start = i * blockSize;
+    let sum = 0;
     for (let j = start; j < Math.min(start + blockSize, channel.length); j++) {
-      sum += channel[j] * channel[j]
+      sum += channel[j] * channel[j];
     }
-    result[i] = Math.sqrt(sum / Math.max(blockSize, 1))
+    result[i] = Math.sqrt(sum / Math.max(blockSize, 1));
   }
-  const max = Math.max(...result, 0.001)
-  return result.map(v => v / max)
+  const max = Math.max(...result, 0.001);
+  return result.map((v) => v / max);
 }
 
 // Pure version of the component's toggleSolo — takes/returns a plain stemState object.
 export function applyToggleSolo(stemState, key) {
-  const wasSoloed = stemState[key].soloed
+  const wasSoloed = stemState[key].soloed;
   const reset = Object.fromEntries(
-    Object.entries(stemState).map(([k, v]) => [k, { ...v, soloed: false }])
-  )
-  if (!wasSoloed) reset[key] = { ...reset[key], soloed: true }
-  return reset
+    Object.entries(stemState).map(([k, v]) => [k, { ...v, soloed: false }]),
+  );
+  if (!wasSoloed) reset[key] = { ...reset[key], soloed: true };
+  return reset;
 }
 
 // Pure version of the component's isMuted(key).
 export function computeMuted(stemState, key) {
-  const anySoloed = Object.values(stemState).some(s => s.soloed)
-  return anySoloed ? !stemState[key].soloed : stemState[key].muted
+  const anySoloed = Object.values(stemState).some((s) => s.soloed);
+  return anySoloed ? !stemState[key].soloed : stemState[key].muted;
 }
 
 export function waveformGradientId(trackId, stemKey) {
-  return `wf-${trackId}-${stemKey}`
+  return `wf-${trackId}-${stemKey}`;
 }

--- a/ui/lib/playback.helpers.test.js
+++ b/ui/lib/playback.helpers.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect } from "vitest";
 import {
   formatTime,
   hashStr,
@@ -7,178 +7,193 @@ import {
   applyToggleSolo,
   computeMuted,
   waveformGradientId,
-} from './playback.helpers.js'
+} from "./playback.helpers.js";
 
 // ── formatTime ──────────────────────────────────────────────
 
-describe('formatTime', () => {
-  it('formats zero as 0:00', () => expect(formatTime(0)).toBe('0:00'))
-  it('formats seconds below a minute', () => expect(formatTime(59)).toBe('0:59'))
-  it('formats exactly one minute', () => expect(formatTime(60)).toBe('1:00'))
-  it('formats mixed minutes and seconds', () => expect(formatTime(90)).toBe('1:30'))
-  it('handles >60 minutes', () => expect(formatTime(3661)).toBe('61:01'))
-  it('returns --:-- for null', () => expect(formatTime(null)).toBe('--:--'))
-  it('returns --:-- for undefined', () => expect(formatTime(undefined)).toBe('--:--'))
-  it('truncates fractional seconds', () => expect(formatTime(1.9)).toBe('0:01'))
-  it('pads seconds with leading zero', () => expect(formatTime(65)).toBe('1:05'))
-})
+describe("formatTime", () => {
+  it("formats zero as 0:00", () => expect(formatTime(0)).toBe("0:00"));
+  it("formats seconds below a minute", () =>
+    expect(formatTime(59)).toBe("0:59"));
+  it("formats exactly one minute", () => expect(formatTime(60)).toBe("1:00"));
+  it("formats mixed minutes and seconds", () =>
+    expect(formatTime(90)).toBe("1:30"));
+  it("handles >60 minutes", () => expect(formatTime(3661)).toBe("61:01"));
+  it("returns --:-- for null", () => expect(formatTime(null)).toBe("--:--"));
+  it("returns --:-- for undefined", () =>
+    expect(formatTime(undefined)).toBe("--:--"));
+  it("truncates fractional seconds", () =>
+    expect(formatTime(1.9)).toBe("0:01"));
+  it("pads seconds with leading zero", () =>
+    expect(formatTime(65)).toBe("1:05"));
+});
 
 // ── hashStr ─────────────────────────────────────────────────
 
-describe('hashStr', () => {
-  it('is deterministic', () => expect(hashStr('hello')).toBe(hashStr('hello')))
-  it('produces different values for different inputs', () => {
-    expect(hashStr('abc')).not.toBe(hashStr('xyz'))
-  })
-  it('returns 0 for empty string', () => expect(hashStr('')).toBe(0))
-  it('returns an unsigned 32-bit integer', () => {
-    const h = hashStr('test')
-    expect(h).toBeGreaterThanOrEqual(0)
-    expect(h).toBeLessThan(2 ** 32)
-    expect(Number.isInteger(h)).toBe(true)
-  })
-})
+describe("hashStr", () => {
+  it("is deterministic", () => expect(hashStr("hello")).toBe(hashStr("hello")));
+  it("produces different values for different inputs", () => {
+    expect(hashStr("abc")).not.toBe(hashStr("xyz"));
+  });
+  it("returns 0 for empty string", () => expect(hashStr("")).toBe(0));
+  it("returns an unsigned 32-bit integer", () => {
+    const h = hashStr("test");
+    expect(h).toBeGreaterThanOrEqual(0);
+    expect(h).toBeLessThan(2 ** 32);
+    expect(Number.isInteger(h)).toBe(true);
+  });
+});
 
 // ── makeWaveformBars ─────────────────────────────────────────
 
-describe('makeWaveformBars', () => {
-  it('returns an array of the requested length', () => {
-    expect(makeWaveformBars('seed', 10)).toHaveLength(10)
-    expect(makeWaveformBars('seed', 120)).toHaveLength(120)
-  })
-  it('all values are in [0.12, 1.0]', () => {
-    const bars = makeWaveformBars('trackid', 100)
+describe("makeWaveformBars", () => {
+  it("returns an array of the requested length", () => {
+    expect(makeWaveformBars("seed", 10)).toHaveLength(10);
+    expect(makeWaveformBars("seed", 120)).toHaveLength(120);
+  });
+  it("all values are in [0.12, 1.0]", () => {
+    const bars = makeWaveformBars("trackid", 100);
     for (const v of bars) {
-      expect(v).toBeGreaterThanOrEqual(0.12)
-      expect(v).toBeLessThanOrEqual(1.0)
+      expect(v).toBeGreaterThanOrEqual(0.12);
+      expect(v).toBeLessThanOrEqual(1.0);
     }
-  })
-  it('is deterministic — same seed produces same array', () => {
-    expect(makeWaveformBars('abc', 50)).toEqual(makeWaveformBars('abc', 50))
-  })
-  it('different seeds produce different arrays', () => {
-    expect(makeWaveformBars('seed1', 20)).not.toEqual(makeWaveformBars('seed2', 20))
-  })
-  it('handles count=0', () => expect(makeWaveformBars('x', 0)).toEqual([]))
-  it('handles count=1', () => expect(makeWaveformBars('x', 1)).toHaveLength(1))
-})
+  });
+  it("is deterministic — same seed produces same array", () => {
+    expect(makeWaveformBars("abc", 50)).toEqual(makeWaveformBars("abc", 50));
+  });
+  it("different seeds produce different arrays", () => {
+    expect(makeWaveformBars("seed1", 20)).not.toEqual(
+      makeWaveformBars("seed2", 20),
+    );
+  });
+  it("handles count=0", () => expect(makeWaveformBars("x", 0)).toEqual([]));
+  it("handles count=1", () => expect(makeWaveformBars("x", 1)).toHaveLength(1));
+});
 
 // ── extractWaveform ──────────────────────────────────────────
 
 function mockAudioBuffer(samples) {
-  return { getChannelData: () => Float32Array.from(samples) }
+  return { getChannelData: () => Float32Array.from(samples) };
 }
 
-describe('extractWaveform', () => {
-  it('returns an array of the requested length', () => {
-    const buf = mockAudioBuffer(new Array(1000).fill(0.5))
-    expect(extractWaveform(buf, 10)).toHaveLength(10)
-  })
-  it('all values are in [0, 1]', () => {
-    const buf = mockAudioBuffer(Array.from({ length: 1000 }, (_, i) => Math.sin(i)))
-    const result = extractWaveform(buf, 20)
+describe("extractWaveform", () => {
+  it("returns an array of the requested length", () => {
+    const buf = mockAudioBuffer(new Array(1000).fill(0.5));
+    expect(extractWaveform(buf, 10)).toHaveLength(10);
+  });
+  it("all values are in [0, 1]", () => {
+    const buf = mockAudioBuffer(
+      Array.from({ length: 1000 }, (_, i) => Math.sin(i)),
+    );
+    const result = extractWaveform(buf, 20);
     for (const v of result) {
-      expect(v).toBeGreaterThanOrEqual(0)
-      expect(v).toBeLessThanOrEqual(1)
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
     }
-  })
-  it('max value is exactly 1 (normalized)', () => {
-    const buf = mockAudioBuffer(Array.from({ length: 400 }, (_, i) => (i % 100 < 50 ? 1 : 0.1)))
-    const result = extractWaveform(buf, 4)
-    expect(Math.max(...result)).toBeCloseTo(1.0, 5)
-  })
-  it('silent buffer (all zeros) returns all zeros', () => {
-    const buf = mockAudioBuffer(new Array(100).fill(0))
-    const result = extractWaveform(buf, 5)
-    for (const v of result) expect(v).toBe(0)
-  })
-  it('handles numPoints=1', () => {
-    const buf = mockAudioBuffer([0.5, 0.8, 0.3])
-    const result = extractWaveform(buf, 1)
-    expect(result).toHaveLength(1)
-    expect(result[0]).toBeCloseTo(1.0, 5)
-  })
-})
+  });
+  it("max value is exactly 1 (normalized)", () => {
+    const buf = mockAudioBuffer(
+      Array.from({ length: 400 }, (_, i) => (i % 100 < 50 ? 1 : 0.1)),
+    );
+    const result = extractWaveform(buf, 4);
+    expect(Math.max(...result)).toBeCloseTo(1.0, 5);
+  });
+  it("silent buffer (all zeros) returns all zeros", () => {
+    const buf = mockAudioBuffer(new Array(100).fill(0));
+    const result = extractWaveform(buf, 5);
+    for (const v of result) expect(v).toBe(0);
+  });
+  it("handles numPoints=1", () => {
+    const buf = mockAudioBuffer([0.5, 0.8, 0.3]);
+    const result = extractWaveform(buf, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeCloseTo(1.0, 5);
+  });
+});
 
 // ── applyToggleSolo / computeMuted ───────────────────────────
 
 function makeStemState(solos = {}, mutes = {}) {
   return Object.fromEntries(
-    ['vocals', 'drums', 'bass', 'other'].map(k => [
+    ["vocals", "drums", "bass", "other"].map((k) => [
       k,
       { muted: mutes[k] ?? false, soloed: solos[k] ?? false, volume: 1 },
-    ])
-  )
+    ]),
+  );
 }
 
-describe('applyToggleSolo', () => {
-  it('soloes an unsolo\'d stem', () => {
-    const s = makeStemState()
-    const next = applyToggleSolo(s, 'bass')
-    expect(next.bass.soloed).toBe(true)
-    expect(next.vocals.soloed).toBe(false)
-    expect(next.drums.soloed).toBe(false)
-  })
-  it('un-soloes a stem that was already soloed', () => {
-    const s = makeStemState({ bass: true })
-    const next = applyToggleSolo(s, 'bass')
-    expect(next.bass.soloed).toBe(false)
-    expect(Object.values(next).every(v => !v.soloed)).toBe(true)
-  })
-  it('switches solo from A to B — only B ends up soloed', () => {
-    const s = makeStemState({ vocals: true })
-    const next = applyToggleSolo(s, 'drums')
-    expect(next.drums.soloed).toBe(true)
-    expect(next.vocals.soloed).toBe(false)
-  })
-  it('does not mutate the original stemState', () => {
-    const s = makeStemState()
-    applyToggleSolo(s, 'bass')
-    expect(s.bass.soloed).toBe(false)
-  })
-})
+describe("applyToggleSolo", () => {
+  it("soloes an unsolo'd stem", () => {
+    const s = makeStemState();
+    const next = applyToggleSolo(s, "bass");
+    expect(next.bass.soloed).toBe(true);
+    expect(next.vocals.soloed).toBe(false);
+    expect(next.drums.soloed).toBe(false);
+  });
+  it("un-soloes a stem that was already soloed", () => {
+    const s = makeStemState({ bass: true });
+    const next = applyToggleSolo(s, "bass");
+    expect(next.bass.soloed).toBe(false);
+    expect(Object.values(next).every((v) => !v.soloed)).toBe(true);
+  });
+  it("switches solo from A to B — only B ends up soloed", () => {
+    const s = makeStemState({ vocals: true });
+    const next = applyToggleSolo(s, "drums");
+    expect(next.drums.soloed).toBe(true);
+    expect(next.vocals.soloed).toBe(false);
+  });
+  it("does not mutate the original stemState", () => {
+    const s = makeStemState();
+    applyToggleSolo(s, "bass");
+    expect(s.bass.soloed).toBe(false);
+  });
+});
 
-describe('computeMuted', () => {
-  it('muted stem with no solo active → true', () => {
-    const s = makeStemState({}, { bass: true })
-    expect(computeMuted(s, 'bass')).toBe(true)
-  })
-  it('unmuted stem with no solo active → false', () => {
-    const s = makeStemState()
-    expect(computeMuted(s, 'bass')).toBe(false)
-  })
-  it('non-soloed stem when a solo is active → true (muted by solo)', () => {
-    const s = makeStemState({ vocals: true })
-    expect(computeMuted(s, 'drums')).toBe(true)
-  })
-  it('soloed stem when a solo is active → false (audible)', () => {
-    const s = makeStemState({ vocals: true })
-    expect(computeMuted(s, 'vocals')).toBe(false)
-  })
-  it('mute flag is ignored when any stem is soloed', () => {
+describe("computeMuted", () => {
+  it("muted stem with no solo active → true", () => {
+    const s = makeStemState({}, { bass: true });
+    expect(computeMuted(s, "bass")).toBe(true);
+  });
+  it("unmuted stem with no solo active → false", () => {
+    const s = makeStemState();
+    expect(computeMuted(s, "bass")).toBe(false);
+  });
+  it("non-soloed stem when a solo is active → true (muted by solo)", () => {
+    const s = makeStemState({ vocals: true });
+    expect(computeMuted(s, "drums")).toBe(true);
+  });
+  it("soloed stem when a solo is active → false (audible)", () => {
+    const s = makeStemState({ vocals: true });
+    expect(computeMuted(s, "vocals")).toBe(false);
+  });
+  it("mute flag is ignored when any stem is soloed", () => {
     // bass is both muted and non-soloed; vocals is soloed
-    const s = makeStemState({ vocals: true }, { bass: true })
+    const s = makeStemState({ vocals: true }, { bass: true });
     // bass mute flag is true but it should just follow the solo logic
-    expect(computeMuted(s, 'bass')).toBe(true) // non-soloed → muted regardless
+    expect(computeMuted(s, "bass")).toBe(true); // non-soloed → muted regardless
     // if bass were the soloed stem, the mute flag should not override it
-    const s2 = makeStemState({ bass: true }, { bass: true })
-    expect(computeMuted(s2, 'bass')).toBe(false) // soloed → audible even if mute flag is set
-  })
-})
+    const s2 = makeStemState({ bass: true }, { bass: true });
+    expect(computeMuted(s2, "bass")).toBe(false); // soloed → audible even if mute flag is set
+  });
+});
 
 // ── waveformGradientId ──────────────────────────────────────
 
-describe('waveformGradientId', () => {
+describe("waveformGradientId", () => {
   it("formats as 'wf-{trackId}-{stemKey}'", () => {
-    expect(waveformGradientId('abc', 'bass')).toBe('wf-abc-bass')
-  })
+    expect(waveformGradientId("abc", "bass")).toBe("wf-abc-bass");
+  });
   it("works for 'master' key", () => {
-    expect(waveformGradientId('abc', 'master')).toBe('wf-abc-master')
-  })
-  it('produces unique IDs for different trackIds', () => {
-    expect(waveformGradientId('t1', 'bass')).not.toBe(waveformGradientId('t2', 'bass'))
-  })
-  it('produces unique IDs for different stemKeys', () => {
-    expect(waveformGradientId('t1', 'bass')).not.toBe(waveformGradientId('t1', 'drums'))
-  })
-})
+    expect(waveformGradientId("abc", "master")).toBe("wf-abc-master");
+  });
+  it("produces unique IDs for different trackIds", () => {
+    expect(waveformGradientId("t1", "bass")).not.toBe(
+      waveformGradientId("t2", "bass"),
+    );
+  });
+  it("produces unique IDs for different stemKeys", () => {
+    expect(waveformGradientId("t1", "bass")).not.toBe(
+      waveformGradientId("t1", "drums"),
+    );
+  });
+});

--- a/ui/lib/tracklist.helpers.js
+++ b/ui/lib/tracklist.helpers.js
@@ -1,61 +1,80 @@
 export function fuzzy(query, target) {
-  query = query.toLowerCase()
-  target = target.toLowerCase()
-  let qi = 0
+  query = query.toLowerCase();
+  target = target.toLowerCase();
+  let qi = 0;
   for (let i = 0; i < target.length && qi < query.length; i++) {
-    if (target[i] === query[qi]) qi++
+    if (target[i] === query[qi]) qi++;
   }
-  return qi === query.length
+  return qi === query.length;
 }
 
 export const SORT_FNS = {
   newest: (a, b) => b.sort_order - a.sort_order,
   oldest: (a, b) => a.sort_order - b.sort_order,
-  title:  (a, b) => a.title.localeCompare(b.title),
-  artist: (a, b) => (a.artist ?? '').localeCompare(b.artist ?? ''),
-}
+  title: (a, b) => a.title.localeCompare(b.title),
+  artist: (a, b) => (a.artist ?? "").localeCompare(b.artist ?? ""),
+};
 
 export function stageLabel(stage) {
-  return { download: 'Downloading…', stems: 'Separating stems…', analysis: 'Analyzing…' }[stage] ?? stage
+  return (
+    {
+      download: "Downloading…",
+      stems: "Separating stems…",
+      analysis: "Analyzing…",
+    }[stage] ?? stage
+  );
 }
 
 export function nextStage(stage) {
-  return { download: 'stems', stems: 'analysis' }[stage]
+  return { download: "stems", stems: "analysis" }[stage];
 }
 
 export function isReady(track) {
-  return track.status_analysis === 'done'
+  return track.status_analysis === "done";
 }
 
 export function hasError(track, progress) {
-  const p = progress?.[track.id]
-  if (p?.status === 'error') return true
-  return track.status_download === 'error' || track.status_stems === 'error' || track.status_analysis === 'error'
+  const p = progress?.[track.id];
+  if (p?.status === "error") return true;
+  return (
+    track.status_download === "error" ||
+    track.status_stems === "error" ||
+    track.status_analysis === "error"
+  );
 }
 
-export const STAGE_PROGRESS = { download: 15, stems: 50, analysis: 85 }
+export const STAGE_PROGRESS = { download: 15, stems: 50, analysis: 85 };
 
 export function progressPct(track, progress) {
-  if (isReady(track)) return 100
-  const p = progress?.[track.id]
-  if (!p) return 0
-  const base = STAGE_PROGRESS[p.stage] ?? 0
-  return p.status === 'done' ? base + 15 : base
+  if (isReady(track)) return 100;
+  const p = progress?.[track.id];
+  if (!p) return 0;
+  const base = STAGE_PROGRESS[p.stage] ?? 0;
+  return p.status === "done" ? base + 15 : base;
 }
 
 export function statusLabel(track, progress) {
-  const p = progress?.[track.id]
+  const p = progress?.[track.id];
   if (p) {
-    if (p.status === 'error') return `Error: ${p.message ?? p.stage}`
-    if (p.status === 'started') return stageLabel(p.stage)
-    if (p.status === 'done' && p.stage !== 'analysis') return stageLabel(nextStage(p.stage))
+    if (p.status === "error") return `Error: ${p.message ?? p.stage}`;
+    if (p.status === "started") return stageLabel(p.stage);
+    if (p.status === "done" && p.stage !== "analysis")
+      return stageLabel(nextStage(p.stage));
   }
-  if (track.status_analysis === 'done') return 'Ready'
-  if (track.status_stems === 'error' || track.status_download === 'error' || track.status_analysis === 'error') {
-    return `Error (${track.error_message ?? 'unknown'})`
+  if (track.status_analysis === "done") return "Ready";
+  if (
+    track.status_stems === "error" ||
+    track.status_download === "error" ||
+    track.status_analysis === "error"
+  ) {
+    return `Error (${track.error_message ?? "unknown"})`;
   }
-  if (track.status_analysis === 'pending' && track.status_stems === 'pending' && track.status_download === 'pending') {
-    return 'Queued'
+  if (
+    track.status_analysis === "pending" &&
+    track.status_stems === "pending" &&
+    track.status_download === "pending"
+  ) {
+    return "Queued";
   }
-  return 'Processing'
+  return "Processing";
 }

--- a/ui/lib/tracklist.helpers.test.js
+++ b/ui/lib/tracklist.helpers.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect } from "vitest";
 import {
   fuzzy,
   SORT_FNS,
@@ -9,185 +9,236 @@ import {
   progressPct,
   statusLabel,
   STAGE_PROGRESS,
-} from './tracklist.helpers.js'
+} from "./tracklist.helpers.js";
 
 const track = (overrides = {}) => ({
-  id: 'abc',
-  title: 'My Track',
+  id: "abc",
+  title: "My Track",
   artist: null,
   sort_order: 1,
-  status_download: 'done',
-  status_stems: 'done',
-  status_analysis: 'done',
+  status_download: "done",
+  status_stems: "done",
+  status_analysis: "done",
   error_message: null,
   ...overrides,
-})
+});
 
-describe('fuzzy', () => {
-  it('matches exact string', () => {
-    expect(fuzzy('bass', 'bass guitar')).toBe(true)
-  })
+describe("fuzzy", () => {
+  it("matches exact string", () => {
+    expect(fuzzy("bass", "bass guitar")).toBe(true);
+  });
 
-  it('matches subsequence', () => {
-    expect(fuzzy('bg', 'bass guitar')).toBe(true)
-  })
+  it("matches subsequence", () => {
+    expect(fuzzy("bg", "bass guitar")).toBe(true);
+  });
 
-  it('is case-insensitive', () => {
-    expect(fuzzy('BASS', 'bass guitar')).toBe(true)
-  })
+  it("is case-insensitive", () => {
+    expect(fuzzy("BASS", "bass guitar")).toBe(true);
+  });
 
-  it('returns false when query does not match', () => {
-    expect(fuzzy('xyz', 'bass guitar')).toBe(false)
-  })
+  it("returns false when query does not match", () => {
+    expect(fuzzy("xyz", "bass guitar")).toBe(false);
+  });
 
-  it('empty query always matches', () => {
-    expect(fuzzy('', 'anything')).toBe(true)
-  })
-})
+  it("empty query always matches", () => {
+    expect(fuzzy("", "anything")).toBe(true);
+  });
+});
 
-describe('SORT_FNS', () => {
-  const a = track({ title: 'Alpha', artist: 'Arlo', sort_order: 1 })
-  const b = track({ title: 'Beta',  artist: 'Zara', sort_order: 2 })
+describe("SORT_FNS", () => {
+  const a = track({ title: "Alpha", artist: "Arlo", sort_order: 1 });
+  const b = track({ title: "Beta", artist: "Zara", sort_order: 2 });
 
-  it('newest: higher sort_order first', () => {
-    expect(SORT_FNS.newest(a, b)).toBeGreaterThan(0)
-    expect(SORT_FNS.newest(b, a)).toBeLessThan(0)
-  })
+  it("newest: higher sort_order first", () => {
+    expect(SORT_FNS.newest(a, b)).toBeGreaterThan(0);
+    expect(SORT_FNS.newest(b, a)).toBeLessThan(0);
+  });
 
-  it('oldest: lower sort_order first', () => {
-    expect(SORT_FNS.oldest(a, b)).toBeLessThan(0)
-  })
+  it("oldest: lower sort_order first", () => {
+    expect(SORT_FNS.oldest(a, b)).toBeLessThan(0);
+  });
 
-  it('title: alphabetical', () => {
-    expect(SORT_FNS.title(a, b)).toBeLessThan(0)
-  })
+  it("title: alphabetical", () => {
+    expect(SORT_FNS.title(a, b)).toBeLessThan(0);
+  });
 
-  it('artist: alphabetical', () => {
-    expect(SORT_FNS.artist(a, b)).toBeLessThan(0)
-  })
-})
+  it("artist: alphabetical", () => {
+    expect(SORT_FNS.artist(a, b)).toBeLessThan(0);
+  });
+});
 
-describe('stageLabel', () => {
-  it('returns human label for known stages', () => {
-    expect(stageLabel('download')).toBe('Downloading…')
-    expect(stageLabel('stems')).toBe('Separating stems…')
-    expect(stageLabel('analysis')).toBe('Analyzing…')
-  })
+describe("stageLabel", () => {
+  it("returns human label for known stages", () => {
+    expect(stageLabel("download")).toBe("Downloading…");
+    expect(stageLabel("stems")).toBe("Separating stems…");
+    expect(stageLabel("analysis")).toBe("Analyzing…");
+  });
 
-  it('falls back to stage name for unknown stage', () => {
-    expect(stageLabel('custom')).toBe('custom')
-  })
-})
+  it("falls back to stage name for unknown stage", () => {
+    expect(stageLabel("custom")).toBe("custom");
+  });
+});
 
-describe('nextStage', () => {
-  it('download → stems', () => expect(nextStage('download')).toBe('stems'))
-  it('stems → analysis', () => expect(nextStage('stems')).toBe('analysis'))
-  it('analysis → undefined', () => expect(nextStage('analysis')).toBeUndefined())
-})
+describe("nextStage", () => {
+  it("download → stems", () => expect(nextStage("download")).toBe("stems"));
+  it("stems → analysis", () => expect(nextStage("stems")).toBe("analysis"));
+  it("analysis → undefined", () =>
+    expect(nextStage("analysis")).toBeUndefined());
+});
 
-describe('isReady', () => {
-  it('true when analysis is done', () => {
-    expect(isReady(track())).toBe(true)
-  })
+describe("isReady", () => {
+  it("true when analysis is done", () => {
+    expect(isReady(track())).toBe(true);
+  });
 
-  it('false when analysis is pending', () => {
-    expect(isReady(track({ status_analysis: 'pending' }))).toBe(false)
-  })
+  it("false when analysis is pending", () => {
+    expect(isReady(track({ status_analysis: "pending" }))).toBe(false);
+  });
 
-  it('false when analysis is error', () => {
-    expect(isReady(track({ status_analysis: 'error' }))).toBe(false)
-  })
-})
+  it("false when analysis is error", () => {
+    expect(isReady(track({ status_analysis: "error" }))).toBe(false);
+  });
+});
 
-describe('hasError', () => {
-  it('false for a fully done track', () => {
-    expect(hasError(track(), {})).toBe(false)
-  })
+describe("hasError", () => {
+  it("false for a fully done track", () => {
+    expect(hasError(track(), {})).toBe(false);
+  });
 
-  it('true when download status is error', () => {
-    expect(hasError(track({ status_download: 'error' }), {})).toBe(true)
-  })
+  it("true when download status is error", () => {
+    expect(hasError(track({ status_download: "error" }), {})).toBe(true);
+  });
 
-  it('true when stems status is error', () => {
-    expect(hasError(track({ status_stems: 'error' }), {})).toBe(true)
-  })
+  it("true when stems status is error", () => {
+    expect(hasError(track({ status_stems: "error" }), {})).toBe(true);
+  });
 
-  it('true when progress reports error', () => {
-    const t = track({ status_download: 'pending', status_stems: 'pending', status_analysis: 'pending' })
-    const progress = { abc: { status: 'error', stage: 'download' } }
-    expect(hasError(t, progress)).toBe(true)
-  })
+  it("true when progress reports error", () => {
+    const t = track({
+      status_download: "pending",
+      status_stems: "pending",
+      status_analysis: "pending",
+    });
+    const progress = { abc: { status: "error", stage: "download" } };
+    expect(hasError(t, progress)).toBe(true);
+  });
 
-  it('false when progress reports started', () => {
-    const t = track({ status_download: 'pending', status_stems: 'pending', status_analysis: 'pending' })
-    const progress = { abc: { status: 'started', stage: 'download' } }
-    expect(hasError(t, progress)).toBe(false)
-  })
-})
+  it("false when progress reports started", () => {
+    const t = track({
+      status_download: "pending",
+      status_stems: "pending",
+      status_analysis: "pending",
+    });
+    const progress = { abc: { status: "started", stage: "download" } };
+    expect(hasError(t, progress)).toBe(false);
+  });
+});
 
-describe('progressPct', () => {
-  it('returns 100 for a ready track', () => {
-    expect(progressPct(track(), {})).toBe(100)
-  })
+describe("progressPct", () => {
+  it("returns 100 for a ready track", () => {
+    expect(progressPct(track(), {})).toBe(100);
+  });
 
-  it('returns 0 when no progress entry exists', () => {
-    const t = track({ status_analysis: 'pending', status_stems: 'pending', status_download: 'pending' })
-    expect(progressPct(t, {})).toBe(0)
-  })
+  it("returns 0 when no progress entry exists", () => {
+    const t = track({
+      status_analysis: "pending",
+      status_stems: "pending",
+      status_download: "pending",
+    });
+    expect(progressPct(t, {})).toBe(0);
+  });
 
-  it('returns base pct when stage is started', () => {
-    const t = track({ status_analysis: 'pending', status_stems: 'pending', status_download: 'pending' })
-    const progress = { abc: { stage: 'stems', status: 'started' } }
-    expect(progressPct(t, progress)).toBe(STAGE_PROGRESS.stems)
-  })
+  it("returns base pct when stage is started", () => {
+    const t = track({
+      status_analysis: "pending",
+      status_stems: "pending",
+      status_download: "pending",
+    });
+    const progress = { abc: { stage: "stems", status: "started" } };
+    expect(progressPct(t, progress)).toBe(STAGE_PROGRESS.stems);
+  });
 
-  it('returns base + 15 when stage is done', () => {
-    const t = track({ status_analysis: 'pending', status_stems: 'pending', status_download: 'pending' })
-    const progress = { abc: { stage: 'download', status: 'done' } }
-    expect(progressPct(t, progress)).toBe(STAGE_PROGRESS.download + 15)
-  })
-})
+  it("returns base + 15 when stage is done", () => {
+    const t = track({
+      status_analysis: "pending",
+      status_stems: "pending",
+      status_download: "pending",
+    });
+    const progress = { abc: { stage: "download", status: "done" } };
+    expect(progressPct(t, progress)).toBe(STAGE_PROGRESS.download + 15);
+  });
+});
 
-describe('statusLabel', () => {
+describe("statusLabel", () => {
   it('"Ready" for fully done track', () => {
-    expect(statusLabel(track(), {})).toBe('Ready')
-  })
+    expect(statusLabel(track(), {})).toBe("Ready");
+  });
 
   it('"Queued" when all stages pending and no progress', () => {
-    const t = track({ status_download: 'pending', status_stems: 'pending', status_analysis: 'pending' })
-    expect(statusLabel(t, {})).toBe('Queued')
-  })
+    const t = track({
+      status_download: "pending",
+      status_stems: "pending",
+      status_analysis: "pending",
+    });
+    expect(statusLabel(t, {})).toBe("Queued");
+  });
 
   it('"Processing" when partially done', () => {
-    const t = track({ status_download: 'done', status_stems: 'pending', status_analysis: 'pending' })
-    expect(statusLabel(t, {})).toBe('Processing')
-  })
+    const t = track({
+      status_download: "done",
+      status_stems: "pending",
+      status_analysis: "pending",
+    });
+    expect(statusLabel(t, {})).toBe("Processing");
+  });
 
-  it('shows error message from DB when stems errored', () => {
-    const t = track({ status_stems: 'error', status_analysis: 'pending', error_message: 'OOM' })
-    expect(statusLabel(t, {})).toBe('Error (OOM)')
-  })
+  it("shows error message from DB when stems errored", () => {
+    const t = track({
+      status_stems: "error",
+      status_analysis: "pending",
+      error_message: "OOM",
+    });
+    expect(statusLabel(t, {})).toBe("Error (OOM)");
+  });
 
   it('shows "unknown" when error_message is null', () => {
-    const t = track({ status_stems: 'error', status_analysis: 'pending', error_message: null })
-    expect(statusLabel(t, {})).toBe('Error (unknown)')
-  })
+    const t = track({
+      status_stems: "error",
+      status_analysis: "pending",
+      error_message: null,
+    });
+    expect(statusLabel(t, {})).toBe("Error (unknown)");
+  });
 
-  it('shows download stage label when download is started', () => {
-    const t = track({ status_download: 'pending', status_stems: 'pending', status_analysis: 'pending' })
-    const progress = { abc: { stage: 'download', status: 'started' } }
-    expect(statusLabel(t, progress)).toBe('Downloading…')
-  })
+  it("shows download stage label when download is started", () => {
+    const t = track({
+      status_download: "pending",
+      status_stems: "pending",
+      status_analysis: "pending",
+    });
+    const progress = { abc: { stage: "download", status: "started" } };
+    expect(statusLabel(t, progress)).toBe("Downloading…");
+  });
 
-  it('shows next stage label when download is done in progress', () => {
-    const t = track({ status_download: 'pending', status_stems: 'pending', status_analysis: 'pending' })
-    const progress = { abc: { stage: 'download', status: 'done' } }
-    expect(statusLabel(t, progress)).toBe('Separating stems…')
-  })
+  it("shows next stage label when download is done in progress", () => {
+    const t = track({
+      status_download: "pending",
+      status_stems: "pending",
+      status_analysis: "pending",
+    });
+    const progress = { abc: { stage: "download", status: "done" } };
+    expect(statusLabel(t, progress)).toBe("Separating stems…");
+  });
 
-  it('shows error from progress', () => {
-    const t = track({ status_download: 'pending', status_stems: 'pending', status_analysis: 'pending' })
-    const progress = { abc: { stage: 'stems', status: 'error', message: 'demucs OOM' } }
-    expect(statusLabel(t, progress)).toBe('Error: demucs OOM')
-  })
-})
+  it("shows error from progress", () => {
+    const t = track({
+      status_download: "pending",
+      status_stems: "pending",
+      status_analysis: "pending",
+    });
+    const progress = {
+      abc: { stage: "stems", status: "error", message: "demucs OOM" },
+    };
+    expect(statusLabel(t, progress)).toBe("Error: demucs OOM");
+  });
+});

--- a/ui/main.js
+++ b/ui/main.js
@@ -1,9 +1,9 @@
-import '@fontsource/oleo-script-swash-caps'
-import { mount } from 'svelte'
-import App from './App.svelte'
+import "@fontsource/oleo-script-swash-caps";
+import { mount } from "svelte";
+import App from "./App.svelte";
 
 const app = mount(App, {
-  target: document.getElementById('app'),
-})
+  target: document.getElementById("app"),
+});
 
-export default app
+export default app;


### PR DESCRIPTION
## Summary

- Fix sticky library header: toolbar (search/sort) now stays fixed while the track list scrolls independently beneath it
- Add linting toolchain: prettier, svelte-check, and `just ci` that mirrors the full CI pipeline
- Apply initial cargo fmt + prettier formatting across the codebase; three svelte-check bugs fixed in the process

## Changes

**Sticky header fix** (`fix: keep library header fixed when scrolling tracks`)
- Wrap track rows in `.tracks-scroll` div with `overflow-y: auto`
- Give `.track-list` and `.list-section` proper flex column layout so the toolbar stays pinned

**Linting toolchain** (`chore: add linting toolchain and CI checks`)
- `prettier` + `prettier-plugin-svelte` + `svelte-check` added as dev deps
- `.prettierrc`, `jsconfig.json` (excludes `dist/` and `*.test.js`)
- `justfile`: `fmt-check`, `fix`, `check-ui`, `lint-ui`, `build-ui`, `install-hooks`; `just ci` now runs the full pipeline matching CI
- CI: `cargo fmt --check` added to Rust workflow; `svelte-check` + `prettier --check` added to frontend workflow

**Initial formatting pass** (`chore: apply initial cargo fmt and prettier formatting`)
- `cargo fmt` across all Rust source files
- `prettier` across all `ui/` files
- Three real bugs caught by svelte-check: `e.target` → `e.currentTarget` in Playback.svelte, empty CSS ruleset removed, computed-key destructuring rewritten in TrackList.svelte

## Test plan

- [ ] `just ci` passes locally
- [ ] Library screen: toolbar stays fixed when scrolling a long track list
- [ ] Playback volume slider still works correctly (`e.currentTarget.value`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)