### PR TITLE
refactor: extract stem names and demucs model into shared constants

### DIFF
--- a/core/src/commands.rs
+++ b/core/src/commands.rs
@@ -6,6 +6,7 @@ use tauri::AppHandle;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
+use crate::constants::STEM_NAMES;
 use crate::db::{self, Track};
 use crate::paths;
 use crate::pipeline::{self, Source};
@@ -256,7 +257,7 @@ pub fn export_stems(
         exported.push("source.wav".to_string());
     }
 
-    for stem in &["bass", "drums", "vocals", "other"] {
+    for stem in STEM_NAMES {
         let src = stems_dir.join(format!("{stem}.wav"));
         if src.exists() {
             let dst = dest.join(format!("{stem}.wav"));

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -1,0 +1,2 @@
+pub const STEM_NAMES: &[&str] = &["bass", "drums", "vocals", "other"];
+pub const DEMUCS_MODEL: &str = "htdemucs";

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,5 @@
 mod commands;
+pub mod constants;
 mod db;
 mod paths;
 mod pipeline;

--- a/core/src/paths.rs
+++ b/core/src/paths.rs
@@ -57,8 +57,8 @@ mod tests {
     #[test]
     fn stem_filenames_are_under_stems_dir() {
         let base = stems_dir(Path::new(DATA), "abc");
-        for name in ["vocals.wav", "drums.wav", "bass.wav", "other.wav"] {
-            assert_eq!(base.join(name).parent().unwrap(), base);
+        for stem in crate::constants::STEM_NAMES {
+            assert_eq!(base.join(format!("{stem}.wav")).parent().unwrap(), base);
         }
     }
 }

--- a/core/src/pipeline/stems.rs
+++ b/core/src/pipeline/stems.rs
@@ -1,3 +1,4 @@
+use crate::constants::{DEMUCS_MODEL, STEM_NAMES};
 use std::path::Path;
 use std::process::Command;
 
@@ -26,7 +27,7 @@ pub fn separate(
         let output = Command::new(demucs_bin)
             .args([
                 "--name",
-                "htdemucs",
+                DEMUCS_MODEL,
                 "-o",
                 tmp.to_str().ok_or("invalid tmp path")?,
                 source_wav.to_str().ok_or("invalid source_wav path")?,
@@ -45,10 +46,10 @@ pub fn separate(
             .and_then(|s| s.to_str())
             .ok_or("invalid source filename")?;
 
-        let demucs_out = tmp.join("htdemucs").join(source_stem);
+        let demucs_out = tmp.join(DEMUCS_MODEL).join(source_stem);
         std::fs::create_dir_all(stems_dir).map_err(|e| format!("mkdir stems_dir: {e}"))?;
 
-        for stem_name in &["bass", "drums", "vocals", "other"] {
+        for stem_name in STEM_NAMES {
             let src = demucs_out.join(format!("{stem_name}.wav"));
             let dst = stems_dir.join(format!("{stem_name}.wav"));
             std::fs::rename(&src, &dst)

--- a/python/analyze.py
+++ b/python/analyze.py
@@ -11,6 +11,9 @@ import sys
 import json
 from pathlib import Path
 
+STEM_NAMES = ("bass", "drums", "vocals", "other")
+HARMONIC_STEMS = tuple(s for s in STEM_NAMES if s != "drums")
+
 try:
     import librosa
     import numpy as np
@@ -95,7 +98,7 @@ def main():
     beat_times = [b["time"] for b in timing["beats"]]
 
     stem_annotations = {}
-    for stem_name in ("bass", "vocals", "other"):
+    for stem_name in HARMONIC_STEMS:
         stem_path = stems_dir / f"{stem_name}.wav"
         if not stem_path.exists():
             print(f"  skipping {stem_name} (not found)", flush=True)


### PR DESCRIPTION
## Summary

Closes #19.

- Adds `core/src/constants.rs` with `STEM_NAMES` and `DEMUCS_MODEL` as the single source of truth for the four stem names and the Demucs model identifier
- Replaces the three independent `["bass", "drums", "vocals", "other"]` literals in `stems.rs`, `commands.rs`, and the `paths.rs` test with `STEM_NAMES`
- Replaces the two `"htdemucs"` string literals in `stems.rs` (CLI arg and output path join) with `DEMUCS_MODEL`
- Adds `STEM_NAMES` / `HARMONIC_STEMS` at the top of `python/analyze.py` so a model change that alters the stem set requires a single edit in each language

## Test plan

- [x] `just ci` passes (Rust fmt/clippy/tests + frontend build/check/prettier)
- [x] All 31 existing unit tests pass unchanged — behaviour is identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)