### PR TITLE
fix: allow multiple stems to be soloed simultaneously

### DIFF
--- a/ui/lib/Playback.svelte
+++ b/ui/lib/Playback.svelte
@@ -35,10 +35,7 @@
   }
 
   function toggleSolo(key) {
-    const wasSoloed = stemState[key].soloed;
-    for (const k of Object.keys(stemState))
-      stemState[k] = { ...stemState[k], soloed: false };
-    if (!wasSoloed) stemState[key] = { ...stemState[key], soloed: true };
+    stemState[key] = { ...stemState[key], soloed: !stemState[key].soloed };
   }
 
   let anySoloed = $derived(Object.values(stemState).some((s) => s.soloed));

--- a/ui/lib/playback.helpers.js
+++ b/ui/lib/playback.helpers.js
@@ -36,12 +36,10 @@ export function extractWaveform(audioBuffer, numPoints) {
 
 // Pure version of the component's toggleSolo — takes/returns a plain stemState object.
 export function applyToggleSolo(stemState, key) {
-  const wasSoloed = stemState[key].soloed;
-  const reset = Object.fromEntries(
-    Object.entries(stemState).map(([k, v]) => [k, { ...v, soloed: false }]),
-  );
-  if (!wasSoloed) reset[key] = { ...reset[key], soloed: true };
-  return reset;
+  return {
+    ...stemState,
+    [key]: { ...stemState[key], soloed: !stemState[key].soloed },
+  };
 }
 
 // Pure version of the component's isMuted(key).

--- a/ui/lib/playback.helpers.test.js
+++ b/ui/lib/playback.helpers.test.js
@@ -136,11 +136,11 @@ describe("applyToggleSolo", () => {
     expect(next.bass.soloed).toBe(false);
     expect(Object.values(next).every((v) => !v.soloed)).toBe(true);
   });
-  it("switches solo from A to B — only B ends up soloed", () => {
+  it("allows multiple stems to be soloed simultaneously", () => {
     const s = makeStemState({ vocals: true });
     const next = applyToggleSolo(s, "drums");
     expect(next.drums.soloed).toBe(true);
-    expect(next.vocals.soloed).toBe(false);
+    expect(next.vocals.soloed).toBe(true);
   });
   it("does not mutate the original stemState", () => {
     const s = makeStemState();

--- a/ui/lib/playback.helpers.test.js
+++ b/ui/lib/playback.helpers.test.js
@@ -142,6 +142,36 @@ describe("applyToggleSolo", () => {
     expect(next.drums.soloed).toBe(true);
     expect(next.vocals.soloed).toBe(true);
   });
+  it("soloing all four stems makes all audible", () => {
+    let s = makeStemState();
+    s = applyToggleSolo(s, "vocals");
+    s = applyToggleSolo(s, "drums");
+    s = applyToggleSolo(s, "bass");
+    s = applyToggleSolo(s, "other");
+    for (const k of ["vocals", "drums", "bass", "other"]) {
+      expect(s[k].soloed).toBe(true);
+    }
+  });
+  it("un-soloing one of multiple keeps the others soloed", () => {
+    const s = makeStemState({ vocals: true, drums: true, bass: true });
+    const next = applyToggleSolo(s, "drums");
+    expect(next.drums.soloed).toBe(false);
+    expect(next.vocals.soloed).toBe(true);
+    expect(next.bass.soloed).toBe(true);
+  });
+  it("un-soloing the last soloed stem clears all solos", () => {
+    const s = makeStemState({ bass: true });
+    const next = applyToggleSolo(s, "bass");
+    expect(Object.values(next).every((v) => !v.soloed)).toBe(true);
+  });
+  it("preserves volume and mute when toggling solo", () => {
+    const s = makeStemState({}, { bass: true });
+    s.bass.volume = 0.5;
+    const next = applyToggleSolo(s, "bass");
+    expect(next.bass.soloed).toBe(true);
+    expect(next.bass.muted).toBe(true);
+    expect(next.bass.volume).toBe(0.5);
+  });
   it("does not mutate the original stemState", () => {
     const s = makeStemState();
     applyToggleSolo(s, "bass");
@@ -167,13 +197,28 @@ describe("computeMuted", () => {
     expect(computeMuted(s, "vocals")).toBe(false);
   });
   it("mute flag is ignored when any stem is soloed", () => {
-    // bass is both muted and non-soloed; vocals is soloed
     const s = makeStemState({ vocals: true }, { bass: true });
-    // bass mute flag is true but it should just follow the solo logic
-    expect(computeMuted(s, "bass")).toBe(true); // non-soloed → muted regardless
-    // if bass were the soloed stem, the mute flag should not override it
+    expect(computeMuted(s, "bass")).toBe(true);
     const s2 = makeStemState({ bass: true }, { bass: true });
-    expect(computeMuted(s2, "bass")).toBe(false); // soloed → audible even if mute flag is set
+    expect(computeMuted(s2, "bass")).toBe(false);
+  });
+  it("multiple soloed stems are all audible", () => {
+    const s = makeStemState({ vocals: true, bass: true });
+    expect(computeMuted(s, "vocals")).toBe(false);
+    expect(computeMuted(s, "bass")).toBe(false);
+    expect(computeMuted(s, "drums")).toBe(true);
+    expect(computeMuted(s, "other")).toBe(true);
+  });
+  it("all stems soloed means none are muted", () => {
+    const s = makeStemState({
+      vocals: true,
+      drums: true,
+      bass: true,
+      other: true,
+    });
+    for (const k of ["vocals", "drums", "bass", "other"]) {
+      expect(computeMuted(s, k)).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Previously, soloing a stem would clear all other solos, so only one stem could be soloed at a time
- Now `toggleSolo` simply toggles the clicked stem's `soloed` flag, allowing multiple stems to be audible together
- The existing `isMuted`/`computeMuted` logic already handled multi-solo correctly — only the toggle needed fixing

## Test plan
- [x] Solo bass → solo drums → both should be audible, vocals and other muted
- [x] Un-solo one of them → remaining soloed stem stays soloed
- [x] Un-solo all → normal playback resumes (mute flags respected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)