### PR TITLE
add: section loop with draggable markers and keyboard shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format:check": "prettier --check \"ui/**/*.{svelte,js,css}\""
   },
   "dependencies": {
+    "@fontsource-variable/material-symbols-rounded": "^5.2.45",
     "@fontsource/oleo-script-swash-caps": "^5.2.8",
     "@tauri-apps/api": "~2.10.1",
     "@tauri-apps/plugin-dialog": "~2.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fontsource-variable/material-symbols-rounded':
+        specifier: ^5.2.45
+        version: 5.2.45
       '@fontsource/oleo-script-swash-caps':
         specifier: ^5.2.8
         version: 5.2.8
@@ -203,6 +206,9 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource-variable/material-symbols-rounded@5.2.45':
+    resolution: {integrity: sha512-CBHbmWtViOI0Qo2+rloF1lTfNEfpW/3JCykh1i3XIJ1xQUY/JCMdf72N9Za4LVuEDJDl7FL3XbSWuMJSyPXRkQ==}
 
   '@fontsource/oleo-script-swash-caps@5.2.8':
     resolution: {integrity: sha512-Sw+k0UDdxpryawovheR24UQYzDA5fWOgmQSsoLp6SG3OP64NcoFGwS088WB/kKbqlDGIRh0xI+eqTOz+S7Zgug==}
@@ -969,6 +975,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.21.5':
     optional: true
+
+  '@fontsource-variable/material-symbols-rounded@5.2.45': {}
 
   '@fontsource/oleo-script-swash-caps@5.2.8': {}
 

--- a/ui/lib/Playback.svelte
+++ b/ui/lib/Playback.svelte
@@ -23,6 +23,15 @@
   let playing = $state(false);
   let playhead = $state(0); // 0–1 fraction
 
+  // ── Loop ────────────────────────────────────────────────────
+  let loopActive = $state(false);
+  let loopStart = $state(1 / 3);
+  let loopEnd = $state(2 / 3);
+  let draggingMarker = $state(null);
+  let loopStartPct = $derived(loopStart * 100);
+  let loopEndPct = $derived(loopEnd * 100);
+  const MIN_LOOP_FRACTION = 0.02;
+
   // ── Stem mixer ─────────────────────────────────────────────
   let stemState = $state(
     Object.fromEntries(
@@ -111,6 +120,9 @@
     playhead = 0;
     buffers = {};
     waveformData = {};
+    loopActive = false;
+    loopStart = 1 / 3;
+    loopEnd = 2 / 3;
 
     try {
       if (!audioCtx) {
@@ -213,7 +225,9 @@
   }
 
   async function seek(fraction) {
-    const safeFraction = Math.max(0, Math.min(1, fraction));
+    let safeFraction = Math.max(0, Math.min(1, fraction));
+    if (loopActive)
+      safeFraction = Math.max(loopStart, Math.min(loopEnd, safeFraction));
     const was = playing;
     if (was) {
       stopSources();
@@ -228,7 +242,13 @@
     }
   }
 
+  let suppressSeek = false;
+
   function seekToClick(e) {
+    if (suppressSeek) {
+      suppressSeek = false;
+      return;
+    }
     const rect = e.currentTarget.getBoundingClientRect();
     seek((e.clientX - rect.left) / rect.width);
   }
@@ -240,6 +260,78 @@
 
   function skipBy(seconds) {
     seek((getCurrentPos() + seconds) / Math.max(duration, 0.001));
+  }
+
+  function toggleLoop() {
+    loopActive = !loopActive;
+    if (loopActive) {
+      const dur = Math.max(duration, 0.001);
+      loopStart = playhead;
+      loopEnd = Math.min(1, playhead + 10 / dur);
+    }
+  }
+
+  // ── Loop marker drag ────────────────────────────────────────
+
+  function applyMarkerDrag(which, frac) {
+    if (which === "start") {
+      loopStart = Math.max(0, Math.min(frac, loopEnd - MIN_LOOP_FRACTION));
+      if (playhead < loopStart) seek(loopStart);
+    } else {
+      loopEnd = Math.min(1, Math.max(frac, loopStart + MIN_LOOP_FRACTION));
+      if (playhead > loopEnd) seek(loopStart);
+    }
+  }
+
+  function onMarkerDown(e, which) {
+    e.preventDefault();
+    e.stopPropagation();
+    draggingMarker = which;
+    const wrap = e.currentTarget.parentElement;
+
+    function onMove(ev) {
+      const rect = wrap.getBoundingClientRect();
+      applyMarkerDrag(
+        which,
+        Math.max(0, Math.min(1, (ev.clientX - rect.left) / rect.width)),
+      );
+    }
+
+    function onUp() {
+      draggingMarker = null;
+      suppressSeek = true;
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    }
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
+
+  function onMarkerTouchStart(e, which) {
+    e.preventDefault();
+    e.stopPropagation();
+    draggingMarker = which;
+    const wrap = e.currentTarget.parentElement;
+
+    function onTouchMove(ev) {
+      const touch = ev.touches[0];
+      const rect = wrap.getBoundingClientRect();
+      applyMarkerDrag(
+        which,
+        Math.max(0, Math.min(1, (touch.clientX - rect.left) / rect.width)),
+      );
+    }
+
+    function onTouchEnd() {
+      draggingMarker = null;
+      suppressSeek = true;
+      window.removeEventListener("touchmove", onTouchMove);
+      window.removeEventListener("touchend", onTouchEnd);
+    }
+
+    window.addEventListener("touchmove", onTouchMove, { passive: false });
+    window.addEventListener("touchend", onTouchEnd);
   }
 
   function schedTick() {
@@ -257,6 +349,25 @@
   function tick() {
     if (!playing || !audioCtx) return;
     const pos = startOffset + (audioCtx.currentTime - startTime);
+
+    if (loopActive && !draggingMarker && pos / duration >= loopEnd) {
+      stopSources();
+      startOffset = loopStart * duration;
+      startTime = audioCtx.currentTime;
+      for (const { key } of STEMS) {
+        const buf = buffers[key];
+        if (!buf) continue;
+        const src = audioCtx.createBufferSource();
+        src.buffer = buf;
+        src.connect(gainNodes[key]);
+        src.start(0, startOffset);
+        sourceNodes[key] = src;
+      }
+      playhead = loopStart;
+      rafId = requestAnimationFrame(tick);
+      return;
+    }
+
     if (pos >= duration) {
       stopSources();
       playing = false;
@@ -327,6 +438,9 @@
     } else if (e.key === "ArrowRight") {
       e.preventDefault();
       skipBy(10);
+    } else if (e.key === "l" || e.key === "L") {
+      e.preventDefault();
+      toggleLoop();
     }
   }}
 />
@@ -380,6 +494,26 @@
             />
           {/each}
         </svg>
+        {#if loopActive}
+          <div
+            class="loop-region"
+            style="left:{loopStartPct}%; width:{loopEndPct - loopStartPct}%"
+          ></div>
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div
+            class="loop-marker"
+            style="left:{loopStartPct}%"
+            onmousedown={(e) => onMarkerDown(e, "start")}
+            ontouchstart={(e) => onMarkerTouchStart(e, "start")}
+          ></div>
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div
+            class="loop-marker"
+            style="left:{loopEndPct}%"
+            onmousedown={(e) => onMarkerDown(e, "end")}
+            ontouchstart={(e) => onMarkerTouchStart(e, "end")}
+          ></div>
+        {/if}
         <div class="playhead" style="left:{playhead * 100}%">
           <div class="playhead-dot"></div>
         </div>
@@ -413,6 +547,18 @@
     <button class="transport-btn" title="Skip to end" onclick={() => seek(1)}
       >›</button
     >
+    <div class="transport-spacer"></div>
+    <button
+      class="transport-btn loop-btn"
+      class:active={loopActive}
+      title={loopActive
+        ? "Disable section loop (L)"
+        : "Enable section loop (L)"}
+      disabled={loading || !!loadError}
+      onclick={toggleLoop}
+    >
+      <span class="material-symbols-rounded">loop</span>
+    </button>
   </div>
 
   <!-- ── Stems ── -->
@@ -625,6 +771,45 @@
     display: block;
   }
 
+  .loop-region {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    background: rgba(76, 175, 114, 0.12);
+    border-left: 1.5px solid rgba(76, 175, 114, 0.5);
+    border-right: 1.5px solid rgba(76, 175, 114, 0.5);
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  .loop-marker {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 12px;
+    transform: translateX(-50%);
+    cursor: ew-resize;
+    z-index: 3;
+  }
+
+  .loop-marker::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 2px;
+    transform: translateX(-50%);
+    background: rgba(76, 175, 114, 0.8);
+    border-radius: 1px;
+  }
+
+  .loop-marker:hover::after,
+  .loop-marker:active::after {
+    background: #4caf72;
+    width: 3px;
+  }
+
   .playhead {
     position: absolute;
     inset: 0 auto;
@@ -691,6 +876,30 @@
   .transport-btn:disabled {
     opacity: 0.35;
     cursor: default;
+  }
+
+  .transport-spacer {
+    width: 12px;
+  }
+
+  .loop-btn {
+    font-size: 12px;
+    letter-spacing: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0 6px;
+  }
+
+  .loop-btn .material-symbols-rounded {
+    font-family: "Material Symbols Rounded Variable";
+    font-size: 16px;
+  }
+
+  .loop-btn.active {
+    background: rgba(76, 175, 114, 0.15);
+    border-color: #4caf72;
+    color: #4caf72;
   }
 
   .play-btn {

--- a/ui/lib/Playback.svelte
+++ b/ui/lib/Playback.svelte
@@ -25,9 +25,9 @@
 
   // ── Loop ────────────────────────────────────────────────────
   let loopActive = $state(false);
-  let loopStart = $state(1 / 3);
-  let loopEnd = $state(2 / 3);
-  let draggingMarker = $state(null);
+  let loopStart = $state(0);
+  let loopEnd = $state(1);
+  let draggingMarker = null;
   let loopStartPct = $derived(loopStart * 100);
   let loopEndPct = $derived(loopEnd * 100);
   const MIN_LOOP_FRACTION = 0.02;
@@ -121,8 +121,8 @@
     buffers = {};
     waveformData = {};
     loopActive = false;
-    loopStart = 1 / 3;
-    loopEnd = 2 / 3;
+    loopStart = 0;
+    loopEnd = 1;
 
     try {
       if (!audioCtx) {
@@ -173,10 +173,7 @@
 
   // ── Playback control ───────────────────────────────────────
 
-  async function startPlayback() {
-    if (!audioCtx || Object.keys(buffers).length === 0) return;
-    if (audioCtx.state !== "running") await audioCtx.resume();
-    const offset = Math.max(0, Math.min(startOffset, duration - 0.01));
+  function startSourcesFrom(offset) {
     startTime = audioCtx.currentTime;
     for (const { key } of STEMS) {
       const buf = buffers[key];
@@ -187,6 +184,12 @@
       src.start(0, offset);
       sourceNodes[key] = src;
     }
+  }
+
+  async function startPlayback() {
+    if (!audioCtx || Object.keys(buffers).length === 0) return;
+    if (audioCtx.state !== "running") await audioCtx.resume();
+    startSourcesFrom(Math.max(0, Math.min(startOffset, duration - 0.01)));
     schedTick();
   }
 
@@ -283,11 +286,12 @@
     }
   }
 
-  function onMarkerDown(e, which) {
+  function onMarkerPointerDown(e, which) {
     e.preventDefault();
     e.stopPropagation();
     draggingMarker = which;
     const wrap = e.currentTarget.parentElement;
+    e.currentTarget.setPointerCapture(e.pointerId);
 
     function onMove(ev) {
       const rect = wrap.getBoundingClientRect();
@@ -300,38 +304,12 @@
     function onUp() {
       draggingMarker = null;
       suppressSeek = true;
-      window.removeEventListener("mousemove", onMove);
-      window.removeEventListener("mouseup", onUp);
+      e.currentTarget.removeEventListener("pointermove", onMove);
+      e.currentTarget.removeEventListener("pointerup", onUp);
     }
 
-    window.addEventListener("mousemove", onMove);
-    window.addEventListener("mouseup", onUp);
-  }
-
-  function onMarkerTouchStart(e, which) {
-    e.preventDefault();
-    e.stopPropagation();
-    draggingMarker = which;
-    const wrap = e.currentTarget.parentElement;
-
-    function onTouchMove(ev) {
-      const touch = ev.touches[0];
-      const rect = wrap.getBoundingClientRect();
-      applyMarkerDrag(
-        which,
-        Math.max(0, Math.min(1, (touch.clientX - rect.left) / rect.width)),
-      );
-    }
-
-    function onTouchEnd() {
-      draggingMarker = null;
-      suppressSeek = true;
-      window.removeEventListener("touchmove", onTouchMove);
-      window.removeEventListener("touchend", onTouchEnd);
-    }
-
-    window.addEventListener("touchmove", onTouchMove, { passive: false });
-    window.addEventListener("touchend", onTouchEnd);
+    e.currentTarget.addEventListener("pointermove", onMove);
+    e.currentTarget.addEventListener("pointerup", onUp);
   }
 
   function schedTick() {
@@ -353,16 +331,7 @@
     if (loopActive && !draggingMarker && pos / duration >= loopEnd) {
       stopSources();
       startOffset = loopStart * duration;
-      startTime = audioCtx.currentTime;
-      for (const { key } of STEMS) {
-        const buf = buffers[key];
-        if (!buf) continue;
-        const src = audioCtx.createBufferSource();
-        src.buffer = buf;
-        src.connect(gainNodes[key]);
-        src.start(0, startOffset);
-        sourceNodes[key] = src;
-      }
+      startSourcesFrom(startOffset);
       playhead = loopStart;
       rafId = requestAnimationFrame(tick);
       return;
@@ -503,15 +472,13 @@
           <div
             class="loop-marker"
             style="left:{loopStartPct}%"
-            onmousedown={(e) => onMarkerDown(e, "start")}
-            ontouchstart={(e) => onMarkerTouchStart(e, "start")}
+            onpointerdown={(e) => onMarkerPointerDown(e, "start")}
           ></div>
           <!-- svelte-ignore a11y_no_static_element_interactions -->
           <div
             class="loop-marker"
             style="left:{loopEndPct}%"
-            onmousedown={(e) => onMarkerDown(e, "end")}
-            ontouchstart={(e) => onMarkerTouchStart(e, "end")}
+            onpointerdown={(e) => onMarkerPointerDown(e, "end")}
           ></div>
         {/if}
         <div class="playhead" style="left:{playhead * 100}%">
@@ -883,11 +850,8 @@
   }
 
   .loop-btn {
-    font-size: 12px;
-    letter-spacing: 0;
     display: inline-flex;
     align-items: center;
-    gap: 4px;
     padding: 0 6px;
   }
 

--- a/ui/lib/Playback.svelte
+++ b/ui/lib/Playback.svelte
@@ -286,6 +286,8 @@
     }
   }
 
+  let cleanupDrag = null;
+
   function onMarkerPointerDown(e, which) {
     e.preventDefault();
     e.stopPropagation();
@@ -303,10 +305,12 @@
     function onUp() {
       draggingMarker = null;
       suppressSeek = true;
+      cleanupDrag = null;
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
     }
 
+    cleanupDrag = onUp;
     window.addEventListener("pointermove", onMove);
     window.addEventListener("pointerup", onUp);
   }
@@ -367,6 +371,7 @@
   });
 
   onDestroy(() => {
+    cleanupDrag?.();
     cancelTick();
     stopSources();
     audioCtx?.close();
@@ -755,6 +760,7 @@
     width: 12px;
     transform: translateX(-50%);
     cursor: ew-resize;
+    touch-action: none;
     z-index: 3;
   }
 

--- a/ui/lib/Playback.svelte
+++ b/ui/lib/Playback.svelte
@@ -291,7 +291,6 @@
     e.stopPropagation();
     draggingMarker = which;
     const wrap = e.currentTarget.parentElement;
-    e.currentTarget.setPointerCapture(e.pointerId);
 
     function onMove(ev) {
       const rect = wrap.getBoundingClientRect();
@@ -304,12 +303,12 @@
     function onUp() {
       draggingMarker = null;
       suppressSeek = true;
-      e.currentTarget.removeEventListener("pointermove", onMove);
-      e.currentTarget.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
     }
 
-    e.currentTarget.addEventListener("pointermove", onMove);
-    e.currentTarget.addEventListener("pointerup", onUp);
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
   }
 
   function schedTick() {

--- a/ui/lib/TrackList.svelte
+++ b/ui/lib/TrackList.svelte
@@ -20,6 +20,7 @@
 
   let filterQuery = $state("");
   let sortKey = $state("newest");
+  let filterInput = $state(null);
 
   function matchesFilter(track) {
     if (!filterQuery) return true;
@@ -179,6 +180,20 @@
   }
 </script>
 
+<svelte:window
+  onkeydown={(e) => {
+    if (
+      e.key === "s" &&
+      !e.metaKey &&
+      !e.ctrlKey &&
+      e.target === document.body
+    ) {
+      e.preventDefault();
+      filterInput?.focus();
+    }
+  }}
+/>
+
 <div class="track-list">
   {#if tracks.length > 0}
     <div class="toolbar">
@@ -186,6 +201,7 @@
         class="filter-input"
         placeholder="Search"
         bind:value={filterQuery}
+        bind:this={filterInput}
       />
       <select class="sort-select" bind:value={sortKey}>
         <option value="newest">Newest</option>

--- a/ui/main.js
+++ b/ui/main.js
@@ -1,4 +1,6 @@
 import "@fontsource/oleo-script-swash-caps";
+// @ts-ignore — font CSS import, no type declarations
+import "@fontsource-variable/material-symbols-rounded";
 import { mount } from "svelte";
 import App from "./App.svelte";
 


### PR DESCRIPTION
## Summary
- **Section loop** in the playback screen: toggle via loop button (Material Symbols icon) or `L` key. Loop start defaults to current playhead position, loop end 10s ahead. Draggable start/end markers on the master waveform with visual green overlay for the loop region.
- **Playback constrained within loop**: seek, skip, and rewind are clamped to loop bounds when active. Dragging markers only resets playback if the marker crosses the current playhead.
- **`S` keyboard shortcut** on the library screen to focus the search bar.
- **Material Symbols Rounded** font added via `@fontsource-variable/material-symbols-rounded` for the loop icon.

## Section Loop screenshot
<img width="912" height="712" alt="Screenshot 2026-05-28 at 14 51 21" src="https://github.com/user-attachments/assets/0bdff317-c757-4c76-9bc1-764b52fa9016" />

## Test plan
- [x] Open a track, click the loop button — markers appear at playhead + 10s region
- [x] Play — playhead loops between markers
- [x] Drag end marker while playing — playback continues uninterrupted unless dragged before playhead
- [x] Drag start marker past playhead — playback jumps to new start
- [x] Press `L` to toggle loop on/off
- [x] Rewind/forward stays within loop bounds
- [x] Switch tracks — loop resets
- [x] On library screen, press `S` — search bar focuses
- [x] `just ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)