### PR TITLE
fix: ci triggers for frontend and python paths

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'ui/**'
+      - 'vite.config.js'
+      - 'vitest.config.js'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - '.github/workflows/ci-frontend.yml'
@@ -12,6 +14,8 @@ on:
     branches: [main]
     paths:
       - 'ui/**'
+      - 'vite.config.js'
+      - 'vitest.config.js'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - '.github/workflows/ci-frontend.yml'

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,0 +1,27 @@
+name: CI (Python)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'python/**'
+      - '.github/workflows/ci-python.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'python/**'
+      - '.github/workflows/ci-python.yml'
+
+jobs:
+  python:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Check syntax
+        run: python -m compileall python/ -q


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` scopes triggers to `core/**` only. Changes to `ui/`, `python/`, `vite.config.js`, or `package.json` never trigger CI. A broken Svelte component, failed Vite build, or Python syntax error would only be caught at release time.

## Changes

1. **`.github/workflows/ci-frontend.yml`** — added `vite.config.js` and `vitest.config.js` to push/PR path triggers so config changes also run the frontend checks.
2. **`.github/workflows/ci-python.yml`** (new) — runs `python -m compileall` on any change to `python/**` to catch syntax errors early, without installing heavy ML dependencies.

Closes #18