### PR TITLE
chore: add structured logging with tracing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ A cross-platform desktop practice app built with Tauri (Rust backend + Svelte fr
 - Separates into stems: bass, drums, vocals, other (Demucs via Poetry)
 - Manages a library of tracks with metadata (title, artist)
 - Exports stems + original audio to a user-chosen folder
-- Full playback screen: synchronized 4-stem Web Audio engine, waveform display, per-stem mute/solo/volume
+- Full playback screen: synchronized 4-stem Web Audio engine, waveform display, per-stem mute/solo/volume, section loop
 - Analysis stage is **stubbed out** — marked done immediately, no actual beat/note detection yet (TODO: MVP v3)
 
 Primary use case: bass player practice with isolated stems.
@@ -51,7 +51,7 @@ Each stage updates the DB and emits a `pipeline` Tauri event `{ track_id, stage,
 | `ui/App.svelte` | Two-screen layout (library ↔ playback slide transition), screen/selectedTrack state |
 | `ui/lib/AddTrack.svelte` | YouTube URL input + local file picker |
 | `ui/lib/TrackList.svelte` | Library: filter, sort, inline edit, progress, export, delete; emits onPlay for ready tracks |
-| `ui/lib/Playback.svelte` | Playback screen: Web Audio engine, waveforms, transport, stem mute/solo/volume, export |
+| `ui/lib/Playback.svelte` | Playback screen: Web Audio engine, waveforms, transport, stem mute/solo/volume, section loop, export |
 | `ui/lib/playback.helpers.js` | Pure functions: formatTime, hashStr, makeWaveformBars, extractWaveform, applyToggleSolo, computeMuted |
 | `python/analyze.py` | Python analysis script (not called yet) |
 | `python/pyproject.toml` | Poetry project: librosa, numpy, demucs (torch 2.6.0) |
@@ -64,9 +64,18 @@ Status values: `pending | done | error`
 
 Migrations are additive via `.ok()` on `ALTER TABLE` in `db::open()`.
 
+## Logging
+
+Structured logging via `tracing` (configured in `lib.rs::run`):
+
+- **File**: JSON format, daily rolling, written to `app_log_dir` (`~/Library/Logs/com.wavesplit.app/` on macOS), falls back to `<app_data_dir>/logs/`
+- **stderr**: Human-readable format, visible during `just dev`
+- **Default level**: `info` — override with `RUST_LOG` env var (e.g. `RUST_LOG=debug just dev`)
+- The `NonBlockingGuard` is held in a `LogGuard` struct managed by Tauri (not leaked) so logs flush on shutdown
+
 ## Stack
 
-- **Backend**: Rust (Tauri 2) — tokio async, rusqlite (bundled SQLite), uuid, chrono
+- **Backend**: Rust (Tauri 2) — tokio async, rusqlite (bundled SQLite), uuid, chrono, tracing
 - **Frontend**: Svelte 5 (runes), Vite, pnpm
 - **External tools**: yt-dlp, ffmpeg (system install); demucs (via Poetry venv in `python/`)
 - **Analysis**: Python 3.11+, Poetry, librosa, numpy, demucs
@@ -119,9 +128,9 @@ CI runs on every push/PR (`ci.yml` for Rust, `ci-frontend.yml` for frontend). Bo
 | Phase   | Status | Features |
 |---------|--------|----------|
 | MVP     | Done   | YouTube/local input, stem separation, library, export |
-| MVP v2  | Done   | Playback engine, waveforms, stem mute/solo/volume |
+| MVP v2  | Done   | Playback engine, waveforms, stem mute/solo/volume, section loop |
 | MVP v3  | Next   | Beat tracking, bass note display |
-| Later   | —      | Chord detection, loop sections |
+| Later   | —      | Chord detection |
 
 ## Commit & PR conventions
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Built with Tauri (Rust + Svelte).
 - Stem separation via [Demucs](https://github.com/facebookresearch/demucs) (bass, drums, vocals, other)
 - Full playback screen with synchronized 4-stem audio engine
 - Per-stem mute, solo, and volume control
+- Section loop with draggable start/end markers
 - Export stems + original audio to any folder
 - Library with search and sort (by newest, oldest, title, or artist)
 - Track metadata editing (title and artist)
@@ -59,7 +60,11 @@ Once a track shows **Ready**, click anywhere on its row to open the playback scr
 
 Click anywhere on the waveform to seek to that position.
 
-### 4. Mix the stems
+### 4. Loop a section
+
+Click the **loop** button (or press **L**) to create a loop region starting at the current playhead. Drag the start/end markers on the waveform to adjust the loop boundaries. Playback automatically wraps back to the loop start when it reaches the end. Press **L** again to disable looping.
+
+### 5. Mix the stems
 
 Each stem row has three controls:
 
@@ -67,11 +72,11 @@ Each stem row has three controls:
 - **S** — solo that stem (exclusive: only the soloed stem plays; click again to clear)
 - **Volume slider** — adjust the level independently
 
-### 5. Edit track metadata
+### 6. Edit track metadata
 
 In the library, click the track title or artist name to edit it inline. Press Enter or click away to save.
 
-### 6. Export stems
+### 7. Export stems
 
 Click **↓ Export stems** on any ready track (in the library or the playback screen) to copy the separated WAV files to a folder of your choice. The exported folder contains:
 
@@ -158,6 +163,12 @@ Each pipeline stage (download → stems → analysis) updates the database and e
 
 Track data is stored in:
 - `~/Library/Application Support/com.wavesplit.app/` (macOS)
+
+Logs are written to:
+- `~/Library/Logs/com.wavesplit.app/wavesplit.log` (macOS) — JSON format, daily rotation
+- stderr — human-readable, visible during `just dev`
+
+Set `RUST_LOG` to control verbosity (defaults to `info`). Example: `RUST_LOG=debug just dev`
 
 ---
 

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2015,6 +2015,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,6 +2168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2271,6 +2286,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-conv"
@@ -3686,6 +3710,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3866,6 +3899,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -4348,6 +4387,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4616,6 +4664,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4633,6 +4694,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4799,6 +4903,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -5020,6 +5130,9 @@ dependencies = [
  "tauri-plugin-opener",
  "tokio",
  "tokio-util",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "url",
  "uuid",
  "which",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,9 @@ which = "6"
 sha2 = "0.10"
 hex = "0.4"
 url = "2"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+tracing-appender = "0.2"
 
 [dev-dependencies]
 tauri = { version = "~2.10", features = ["test"] }

--- a/core/src/commands.rs
+++ b/core/src/commands.rs
@@ -56,7 +56,10 @@ fn spawn_pipeline<R: tauri::Runtime>(
     state
         .tasks
         .lock()
-        .unwrap_or_else(|e| e.into_inner())
+        .unwrap_or_else(|e| {
+            tracing::warn!(track_id, "tasks mutex poisoned, recovering");
+            e.into_inner()
+        })
         .insert(track_id.clone(), token.clone());
     let tasks = Arc::clone(&state.tasks);
     let db = Arc::clone(&state.db);
@@ -129,7 +132,10 @@ pub async fn add_track_youtube(
             });
         }
     }
-    let title = pipeline::download::youtube_title(&url).unwrap_or_else(|| url.clone());
+    let title = pipeline::download::youtube_title(&url).unwrap_or_else(|| {
+        tracing::info!("failed to extract YouTube title, falling back to URL");
+        url.clone()
+    });
     let id = add_track(
         Source::Youtube(url.clone()),
         title,
@@ -467,6 +473,55 @@ mod tests {
         assert!(
             result.unwrap_err().contains("already processing"),
             "should reject already running track"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_pipeline_logs_warning_on_poisoned_mutex() {
+        let tasks: Arc<Mutex<HashMap<String, CancellationToken>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        // Poison the mutex
+        let tasks2 = Arc::clone(&tasks);
+        let _ = std::thread::spawn(move || {
+            let _guard = tasks2.lock().unwrap();
+            panic!("intentional panic to poison mutex");
+        })
+        .join();
+
+        let (capture, _guard) = crate::test_support::TracingCapture::new();
+
+        let db = Arc::new(Mutex::new(
+            crate::db::open(std::path::Path::new(":memory:")).unwrap(),
+        ));
+        let state = AppState {
+            db,
+            data_dir: std::path::PathBuf::from("/tmp"),
+            demucs_dir: std::path::PathBuf::from("/tmp"),
+            tasks: Arc::clone(&tasks),
+        };
+
+        let app = tauri::test::mock_app();
+        let id = "test-poison-id".to_string();
+
+        spawn_pipeline(
+            id.clone(),
+            pipeline::Source::Local(std::path::PathBuf::from("/dev/null")),
+            &state,
+            app.handle().clone(),
+            pipeline::StartStage::Analysis,
+        );
+
+        assert!(
+            capture.contains("WARN", "tasks mutex poisoned"),
+            "expected warning about poisoned mutex, got: {:?}",
+            capture.events()
+        );
+
+        // Should still have inserted the task despite the poison
+        let guard = tasks.lock().unwrap_or_else(|e| e.into_inner());
+        assert!(
+            guard.contains_key(&id),
+            "task should be in map despite poison"
         );
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Manager};
 use tokio_util::sync::CancellationToken;
+use tracing_subscriber::{fmt, prelude::*, registry, EnvFilter};
 
 pub struct AppState {
     pub db: Arc<Mutex<Connection>>,
@@ -62,6 +63,78 @@ async fn download_demucs(app: AppHandle, state: tauri::State<'_, AppState>) -> R
     setup::download(&demucs_dir, &app).await
 }
 
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::sync::{Arc, Mutex};
+    use tracing::field::{Field, Visit};
+    use tracing::Event;
+    use tracing::Subscriber;
+    use tracing_subscriber::layer::Context;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::Layer;
+
+    #[derive(Clone, Default)]
+    pub struct TracingCapture {
+        events: Arc<Mutex<Vec<(String, String)>>>,
+    }
+
+    impl TracingCapture {
+        pub fn new() -> (Self, tracing::subscriber::DefaultGuard) {
+            let this = Self::default();
+            let layer = CaptureLayer {
+                capture: this.clone(),
+            };
+            let subscriber = tracing_subscriber::registry().with(layer);
+            let guard = tracing::subscriber::set_default(subscriber);
+            (this, guard)
+        }
+
+        pub fn events(&self) -> Vec<(String, String)> {
+            self.events.lock().unwrap().clone()
+        }
+
+        pub fn contains(&self, level: &str, needle: &str) -> bool {
+            self.events()
+                .iter()
+                .any(|(lvl, msg)| lvl == level && msg.contains(needle))
+        }
+    }
+
+    struct CaptureLayer {
+        capture: TracingCapture,
+    }
+
+    struct CaptureVisitor(String);
+
+    impl Visit for CaptureVisitor {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            if !self.0.is_empty() {
+                self.0.push(' ');
+            }
+            use std::fmt::Write;
+            write!(self.0, "{}={:?}", field.name(), value).unwrap();
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            if !self.0.is_empty() {
+                self.0.push(' ');
+            }
+            use std::fmt::Write;
+            write!(self.0, "{}={:?}", field.name(), value).unwrap();
+        }
+    }
+
+    impl<S: Subscriber> Layer<S> for CaptureLayer {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            let mut visitor = CaptureVisitor(String::new());
+            event.record(&mut visitor);
+            let level = event.metadata().level().to_string();
+            let mut events = self.capture.events.lock().unwrap();
+            events.push((level, visitor.0));
+        }
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run(ctx: tauri::Context) {
     tauri::Builder::default()
@@ -71,13 +144,41 @@ pub fn run(ctx: tauri::Context) {
             let data_dir = app.path().app_data_dir()?;
             std::fs::create_dir_all(data_dir.join("tracks"))?;
 
+            let log_dir = app
+                .path()
+                .app_log_dir()
+                .unwrap_or_else(|_| data_dir.join("logs"));
+            std::fs::create_dir_all(&log_dir).ok();
+            let file_appender = tracing_appender::rolling::daily(&log_dir, "wavesplit.log");
+            let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+            // Leak the guard so it lives for the application lifetime
+            std::mem::forget(_guard);
+            registry()
+                .with(
+                    fmt::Layer::new()
+                        .json()
+                        .with_writer(non_blocking)
+                        .with_target(true)
+                        .with_thread_ids(true),
+                )
+                .with(
+                    fmt::Layer::new()
+                        .with_writer(std::io::stderr)
+                        .with_target(true)
+                        .with_thread_ids(true),
+                )
+                .with(EnvFilter::from_default_env())
+                .init();
+
             let demucs_dir = data_dir.join("demucs");
             std::fs::create_dir_all(&demucs_dir)?;
 
             let db_path = data_dir.join("wavesplit.db");
             let conn = db::open(&db_path)?;
 
-            db::mark_interrupted(&conn).unwrap_or_default();
+            if let Err(e) = db::mark_interrupted(&conn) {
+                tracing::warn!(error = %e, "failed to mark interrupted tracks");
+            }
 
             app.manage(AppState {
                 db: Arc::new(Mutex::new(conn)),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,6 +22,10 @@ pub struct AppState {
     pub tasks: Arc<Mutex<HashMap<String, CancellationToken>>>,
 }
 
+/// Holds the tracing-appender guard so log buffers flush on shutdown.
+#[allow(dead_code)]
+struct LogGuard(tracing_appender::non_blocking::WorkerGuard);
+
 #[tauri::command]
 fn list_tracks(state: tauri::State<AppState>) -> Result<Vec<db::Track>, String> {
     let conn = state
@@ -150,9 +154,7 @@ pub fn run(ctx: tauri::Context) {
                 .unwrap_or_else(|_| data_dir.join("logs"));
             std::fs::create_dir_all(&log_dir).ok();
             let file_appender = tracing_appender::rolling::daily(&log_dir, "wavesplit.log");
-            let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
-            // Leak the guard so it lives for the application lifetime
-            std::mem::forget(_guard);
+            let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
             registry()
                 .with(
                     fmt::Layer::new()
@@ -167,8 +169,9 @@ pub fn run(ctx: tauri::Context) {
                         .with_target(true)
                         .with_thread_ids(true),
                 )
-                .with(EnvFilter::from_default_env())
+                .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
                 .init();
+            app.manage(LogGuard(guard));
 
             let demucs_dir = data_dir.join("demucs");
             std::fs::create_dir_all(&demucs_dir)?;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -67,6 +67,76 @@ async fn download_demucs(app: AppHandle, state: tauri::State<'_, AppState>) -> R
     setup::download(&demucs_dir, &app).await
 }
 
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run(ctx: tauri::Context) {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
+        .setup(|app| {
+            let data_dir = app.path().app_data_dir()?;
+            std::fs::create_dir_all(data_dir.join("tracks"))?;
+
+            let log_dir = app
+                .path()
+                .app_log_dir()
+                .unwrap_or_else(|_| data_dir.join("logs"));
+            std::fs::create_dir_all(&log_dir).ok();
+            let file_appender = tracing_appender::rolling::daily(&log_dir, "wavesplit.log");
+            let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+            registry()
+                .with(
+                    fmt::Layer::new()
+                        .json()
+                        .with_writer(non_blocking)
+                        .with_target(true)
+                        .with_thread_ids(true),
+                )
+                .with(
+                    fmt::Layer::new()
+                        .with_writer(std::io::stderr)
+                        .with_target(true)
+                        .with_thread_ids(true),
+                )
+                .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+                .init();
+            app.manage(LogGuard(guard));
+
+            let demucs_dir = data_dir.join("demucs");
+            std::fs::create_dir_all(&demucs_dir)?;
+
+            let db_path = data_dir.join("wavesplit.db");
+            let conn = db::open(&db_path)?;
+
+            if let Err(e) = db::mark_interrupted(&conn) {
+                tracing::warn!(error = %e, "failed to mark interrupted tracks");
+            }
+
+            app.manage(AppState {
+                db: Arc::new(Mutex::new(conn)),
+                data_dir,
+                demucs_dir,
+                tasks: Arc::new(Mutex::new(HashMap::new())),
+            });
+
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![
+            list_tracks,
+            delete_track,
+            check_demucs,
+            download_demucs,
+            commands::add_track_youtube,
+            commands::add_track_local,
+            commands::export_stems,
+            commands::update_track_meta,
+            commands::open_folder,
+            commands::retry_track,
+            commands::get_stem_paths,
+        ])
+        .run(ctx)
+        .expect("error while running tauri application");
+}
+
 #[cfg(test)]
 pub(crate) mod test_support {
     use std::sync::{Arc, Mutex};
@@ -137,74 +207,4 @@ pub(crate) mod test_support {
             events.push((level, visitor.0));
         }
     }
-}
-
-#[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run(ctx: tauri::Context) {
-    tauri::Builder::default()
-        .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_plugin_dialog::init())
-        .setup(|app| {
-            let data_dir = app.path().app_data_dir()?;
-            std::fs::create_dir_all(data_dir.join("tracks"))?;
-
-            let log_dir = app
-                .path()
-                .app_log_dir()
-                .unwrap_or_else(|_| data_dir.join("logs"));
-            std::fs::create_dir_all(&log_dir).ok();
-            let file_appender = tracing_appender::rolling::daily(&log_dir, "wavesplit.log");
-            let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
-            registry()
-                .with(
-                    fmt::Layer::new()
-                        .json()
-                        .with_writer(non_blocking)
-                        .with_target(true)
-                        .with_thread_ids(true),
-                )
-                .with(
-                    fmt::Layer::new()
-                        .with_writer(std::io::stderr)
-                        .with_target(true)
-                        .with_thread_ids(true),
-                )
-                .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
-                .init();
-            app.manage(LogGuard(guard));
-
-            let demucs_dir = data_dir.join("demucs");
-            std::fs::create_dir_all(&demucs_dir)?;
-
-            let db_path = data_dir.join("wavesplit.db");
-            let conn = db::open(&db_path)?;
-
-            if let Err(e) = db::mark_interrupted(&conn) {
-                tracing::warn!(error = %e, "failed to mark interrupted tracks");
-            }
-
-            app.manage(AppState {
-                db: Arc::new(Mutex::new(conn)),
-                data_dir,
-                demucs_dir,
-                tasks: Arc::new(Mutex::new(HashMap::new())),
-            });
-
-            Ok(())
-        })
-        .invoke_handler(tauri::generate_handler![
-            list_tracks,
-            delete_track,
-            check_demucs,
-            download_demucs,
-            commands::add_track_youtube,
-            commands::add_track_local,
-            commands::export_stems,
-            commands::update_track_meta,
-            commands::open_folder,
-            commands::retry_track,
-            commands::get_stem_paths,
-        ])
-        .run(ctx)
-        .expect("error while running tauri application");
 }

--- a/core/src/pipeline/analysis.rs
+++ b/core/src/pipeline/analysis.rs
@@ -63,15 +63,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn project_dir_returns_non_empty_path() {
-        let dir = project_dir();
-        assert!(
-            !dir.as_os_str().is_empty(),
-            "project_dir should return a non-empty path"
-        );
-    }
-
-    #[test]
     fn project_dir_does_not_log_warning_when_exe_available() {
         let (capture, _guard) = crate::test_support::TracingCapture::new();
         let _dir = project_dir();

--- a/core/src/pipeline/analysis.rs
+++ b/core/src/pipeline/analysis.rs
@@ -6,7 +6,10 @@ use std::process::Command;
 /// Resolve the Poetry project directory containing pyproject.toml and analyze.py.
 /// In dev: core/target/debug/wavesplit → ../../../python/
 pub fn project_dir() -> std::path::PathBuf {
-    let exe = std::env::current_exe().unwrap_or_default();
+    let exe = std::env::current_exe().unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "failed to get current exe path");
+        std::path::PathBuf::new()
+    });
     // dev path: core/target/debug/wavesplit → up 4 levels to repo root, then python/
     let dev_path = exe
         .parent()
@@ -53,4 +56,46 @@ pub fn run(stems_dir: &Path, analysis_dir: &Path) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_dir_returns_non_empty_path() {
+        let dir = project_dir();
+        assert!(
+            !dir.as_os_str().is_empty(),
+            "project_dir should return a non-empty path"
+        );
+    }
+
+    #[test]
+    fn project_dir_does_not_log_warning_when_exe_available() {
+        let (capture, _guard) = crate::test_support::TracingCapture::new();
+        let _dir = project_dir();
+        assert!(
+            !capture.contains("WARN", "failed to get current exe path"),
+            "expected no warning on happy path, got: {:?}",
+            capture.events()
+        );
+    }
+
+    #[test]
+    fn run_errors_when_script_missing() {
+        let project_dir = project_dir();
+        // Use the project dir's parent as a fake stems/analysis dir to ensure
+        // the script path won't match.
+        let fake_dir = project_dir.join("nonexistent_subdir_xyz");
+        let result = run(Path::new("/tmp"), &fake_dir);
+        assert!(
+            result.is_err(),
+            "expected Err when analyze.py is missing, got Ok"
+        );
+        assert!(
+            result.unwrap_err().contains("analyze.py not found"),
+            "error should mention missing script"
+        );
+    }
 }

--- a/core/src/pipeline/download.rs
+++ b/core/src/pipeline/download.rs
@@ -87,6 +87,10 @@ pub fn youtube_title(url: &str) -> Option<String> {
             url,
         ])
         .output()
+        .map_err(|e| {
+            tracing::debug!(error = %e, "yt-dlp title extraction failed");
+            e
+        })
         .ok()?;
     if output.status.success() {
         Some(String::from_utf8_lossy(&output.stdout).trim().to_string())

--- a/core/src/pipeline/mod.rs
+++ b/core/src/pipeline/mod.rs
@@ -311,8 +311,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_emits_trace_info_on_analysis_stage_boundaries() {
-        let (capture, guard) = crate::test_support::TracingCapture::new();
-        let _ = guard;
+        let (capture, _guard) = crate::test_support::TracingCapture::new();
 
         let conn = open_mem();
         insert_pending(&conn, "t-trace");

--- a/core/src/pipeline/mod.rs
+++ b/core/src/pipeline/mod.rs
@@ -115,7 +115,7 @@ pub async fn run<R: Runtime>(
         if token.is_cancelled() {
             return;
         }
-        info!(track_id = %track_id, stage = "download", status = "started");
+        info!(%track_id, stage = "download", status = "started");
         emit(&app, &track_id, "download", "started", None);
         let dl_result = tokio::task::spawn_blocking({
             let source_wav = source_wav.clone();
@@ -142,11 +142,11 @@ pub async fn run<R: Runtime>(
         }
         match dl_result {
             Ok(_) => {
-                info!(track_id = %track_id, stage = "download", status = "done");
+                info!(%track_id, stage = "download", status = "done");
                 emit(&app, &track_id, "download", "done", None);
             }
             Err(e) => {
-                error!(track_id = %track_id, stage = "download", status = "error", message = %e);
+                error!(%track_id, stage = "download", status = "error", message = %e);
                 emit(&app, &track_id, "download", "error", Some(e));
                 return;
             }
@@ -170,7 +170,7 @@ pub async fn run<R: Runtime>(
         if token.is_cancelled() {
             return;
         }
-        info!(track_id = %track_id, stage = "stems", status = "started");
+        info!(%track_id, stage = "stems", status = "started");
         emit(&app, &track_id, "stems", "started", None);
         let stems_result = tokio::task::spawn_blocking({
             let source_wav = source_wav.clone();
@@ -195,11 +195,11 @@ pub async fn run<R: Runtime>(
         }
         match stems_result {
             Ok(_) => {
-                info!(track_id = %track_id, stage = "stems", status = "done");
+                info!(%track_id, stage = "stems", status = "done");
                 emit(&app, &track_id, "stems", "done", None);
             }
             Err(e) => {
-                error!(track_id = %track_id, stage = "stems", status = "error", message = %e);
+                error!(%track_id, stage = "stems", status = "error", message = %e);
                 emit(&app, &track_id, "stems", "error", Some(e));
                 return;
             }
@@ -210,7 +210,7 @@ pub async fn run<R: Runtime>(
     if token.is_cancelled() {
         return;
     }
-    info!(track_id = %track_id, stage = "analysis", status = "started");
+    info!(%track_id, stage = "analysis", status = "started");
     // TODO: re-enable analysis once beat/note detection is ready (MVP v2)
     {
         let conn = lock_or_abort!(&db, &app, &track_id, "analysis");
@@ -231,7 +231,7 @@ pub async fn run<R: Runtime>(
             return;
         }
     }
-    info!(track_id = %track_id, stage = "analysis", status = "done");
+    info!(%track_id, stage = "analysis", status = "done");
     emit(&app, &track_id, "analysis", "done", None);
 }
 
@@ -311,7 +311,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_emits_trace_info_on_analysis_stage_boundaries() {
-        let (_capture, _guard) = crate::test_support::TracingCapture::new();
+        let (capture, _guard) = crate::test_support::TracingCapture::new();
 
         let conn = open_mem();
         insert_pending(&conn, "t-trace");
@@ -332,14 +332,14 @@ mod tests {
         .await;
 
         assert!(
-            _capture.contains("INFO", r#"stage="analysis" status="started""#),
+            capture.contains("INFO", r#"stage="analysis" status="started""#),
             "expected analysis started info event, got: {:?}",
-            _capture.events()
+            capture.events()
         );
         assert!(
-            _capture.contains("INFO", r#"stage="analysis" status="done""#),
+            capture.contains("INFO", r#"stage="analysis" status="done""#),
             "expected analysis done info event, got: {:?}",
-            _capture.events()
+            capture.events()
         );
     }
 

--- a/core/src/pipeline/mod.rs
+++ b/core/src/pipeline/mod.rs
@@ -8,6 +8,8 @@ use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter, Runtime};
 use tokio_util::sync::CancellationToken;
 
+use tracing::{error, info, warn};
+
 use crate::db;
 use crate::paths;
 use crate::setup;
@@ -76,8 +78,7 @@ fn emit<R: Runtime>(
             message,
         },
     ) {
-        // TODO: replace with structured logging once #22 lands
-        eprintln!("[pipeline] emit failed for track={track_id} stage={stage}: {e}");
+        warn!(track_id, stage, error = %e, "pipeline emit failed");
     }
 }
 
@@ -114,6 +115,7 @@ pub async fn run<R: Runtime>(
         if token.is_cancelled() {
             return;
         }
+        info!(track_id = %track_id, stage = "download", status = "started");
         emit(&app, &track_id, "download", "started", None);
         let dl_result = tokio::task::spawn_blocking({
             let source_wav = source_wav.clone();
@@ -139,8 +141,12 @@ pub async fn run<R: Runtime>(
             }
         }
         match dl_result {
-            Ok(_) => emit(&app, &track_id, "download", "done", None),
+            Ok(_) => {
+                info!(track_id = %track_id, stage = "download", status = "done");
+                emit(&app, &track_id, "download", "done", None);
+            }
             Err(e) => {
+                error!(track_id = %track_id, stage = "download", status = "error", message = %e);
                 emit(&app, &track_id, "download", "error", Some(e));
                 return;
             }
@@ -164,6 +170,7 @@ pub async fn run<R: Runtime>(
         if token.is_cancelled() {
             return;
         }
+        info!(track_id = %track_id, stage = "stems", status = "started");
         emit(&app, &track_id, "stems", "started", None);
         let stems_result = tokio::task::spawn_blocking({
             let source_wav = source_wav.clone();
@@ -187,8 +194,12 @@ pub async fn run<R: Runtime>(
             }
         }
         match stems_result {
-            Ok(_) => emit(&app, &track_id, "stems", "done", None),
+            Ok(_) => {
+                info!(track_id = %track_id, stage = "stems", status = "done");
+                emit(&app, &track_id, "stems", "done", None);
+            }
             Err(e) => {
+                error!(track_id = %track_id, stage = "stems", status = "error", message = %e);
                 emit(&app, &track_id, "stems", "error", Some(e));
                 return;
             }
@@ -199,6 +210,7 @@ pub async fn run<R: Runtime>(
     if token.is_cancelled() {
         return;
     }
+    info!(track_id = %track_id, stage = "analysis", status = "started");
     // TODO: re-enable analysis once beat/note detection is ready (MVP v2)
     {
         let conn = lock_or_abort!(&db, &app, &track_id, "analysis");
@@ -219,6 +231,7 @@ pub async fn run<R: Runtime>(
             return;
         }
     }
+    info!(track_id = %track_id, stage = "analysis", status = "done");
     emit(&app, &track_id, "analysis", "done", None);
 }
 
@@ -294,6 +307,78 @@ mod tests {
         let track = crate::db::get_track(&conn, "t2").unwrap().unwrap();
         assert_eq!(track.status_stems, "error");
         assert_eq!(track.error_message.as_deref(), Some("demucs crashed"));
+    }
+
+    #[tokio::test]
+    async fn run_emits_trace_info_on_analysis_stage_boundaries() {
+        let (_capture, _guard) = crate::test_support::TracingCapture::new();
+
+        let conn = open_mem();
+        insert_pending(&conn, "t-trace");
+        let db = Arc::new(Mutex::new(conn));
+
+        let app = tauri::test::mock_app();
+
+        run(
+            "t-trace".to_string(),
+            Source::Local(std::path::PathBuf::from("/dev/null")),
+            db,
+            std::path::PathBuf::from("/tmp"),
+            std::path::PathBuf::from("/tmp"),
+            CancellationToken::new(),
+            app.handle().clone(),
+            StartStage::Analysis,
+        )
+        .await;
+
+        assert!(
+            _capture.contains("INFO", r#"stage="analysis" status="started""#),
+            "expected analysis started info event, got: {:?}",
+            _capture.events()
+        );
+        assert!(
+            _capture.contains("INFO", r#"stage="analysis" status="done""#),
+            "expected analysis done info event, got: {:?}",
+            _capture.events()
+        );
+    }
+
+    #[tokio::test]
+    async fn run_emits_trace_error_when_analysis_db_write_fails() {
+        let (capture, _guard) = crate::test_support::TracingCapture::new();
+
+        let conn = crate::db::open(std::path::Path::new(":memory:")).unwrap();
+        conn.execute("DROP TABLE tracks", []).unwrap();
+        let db = Arc::new(Mutex::new(conn));
+
+        let app = tauri::test::mock_app();
+
+        run(
+            "t-trace-fail".to_string(),
+            Source::Local(std::path::PathBuf::from("/dev/null")),
+            db,
+            std::path::PathBuf::from("/tmp"),
+            std::path::PathBuf::from("/tmp"),
+            CancellationToken::new(),
+            app.handle().clone(),
+            StartStage::Analysis,
+        )
+        .await;
+
+        assert!(
+            capture.contains("INFO", r#"stage="analysis" status="started""#),
+            "expected analysis started info event"
+        );
+        assert!(
+            capture.contains("INFO", "track_id=t-trace-fail"),
+            "expected track_id in event fields, got: {:?}",
+            capture.events()
+        );
+        // The DB write fails after "started", so "done" should not appear
+        assert!(
+            !capture.contains("INFO", r#"stage="analysis" status="done""#),
+            "analysis done should not be emitted on DB failure"
+        );
     }
 
     /// Simulate a DB failure mid-pipeline: drop the schema so the analysis

--- a/core/src/pipeline/mod.rs
+++ b/core/src/pipeline/mod.rs
@@ -311,7 +311,8 @@ mod tests {
 
     #[tokio::test]
     async fn run_emits_trace_info_on_analysis_stage_boundaries() {
-        let (capture, _guard) = crate::test_support::TracingCapture::new();
+        let (capture, guard) = crate::test_support::TracingCapture::new();
+        let _ = guard;
 
         let conn = open_mem();
         insert_pending(&conn, "t-trace");

--- a/core/src/pipeline/stems.rs
+++ b/core/src/pipeline/stems.rs
@@ -59,6 +59,8 @@ pub fn separate(
         Ok(())
     })();
 
-    let _ = std::fs::remove_dir_all(&tmp);
+    if let Err(e) = std::fs::remove_dir_all(&tmp) {
+        tracing::warn!(error = %e, "failed to remove demucs temp dir");
+    }
     result
 }

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -155,14 +155,16 @@ pub async fn download(demucs_dir: &Path, app: &AppHandle) -> Result<(), String> 
             .await
             .map_err(|e| format!("write error: {e}"))?;
 
-        let _ = app.emit(
+        if let Err(e) = app.emit(
             "setup:progress",
             DownloadProgress {
                 downloaded_mb: downloaded as f64 / 1_048_576.0,
                 total_mb: total_bytes.map(|t| t as f64 / 1_048_576.0),
                 percent: total_bytes.map(|t| (downloaded * 100 / t) as u32),
             },
-        );
+        ) {
+            tracing::trace!(error = %e, "setup:progress emit failed");
+        }
     }
 
     use tokio::io::AsyncWriteExt;


### PR DESCRIPTION
Closes #22

Replaces bare `eprintln!` with `tracing::warn!` / `tracing::info!` / `tracing::error!` across the codebase. Configures a `tracing-subscriber` registry with:
- JSON rolling file appender (daily) writing to `app_log_dir`
- Human-readable stderr output
- `EnvFilter` (reads `RUST_LOG`, defaults to `info`)

### Changes

| File | What |
|------|------|
| `core/Cargo.toml` | Add `tracing`, `tracing-subscriber`, `tracing-appender` deps |
| `core/src/lib.rs` | Init tracing in `setup` closure; wrap `mark_interrupted` with `tracing::warn!` |
| `core/src/pipeline/mod.rs` | Replace `eprintln!` with `tracing::warn!`; `info!`/ `error!` at each stage boundary |
| `core/src/commands.rs` | `tracing::warn!` on tasks mutex poison; `tracing::info!` on YT title fallback |
| `core/src/pipeline/stems.rs` | `tracing::warn!` on demucs temp cleanup failure |
| `core/src/setup.rs` | `tracing::trace!` on progress emit failure |
| `core/src/pipeline/download.rs` | `tracing::debug!` on yt-dlp title command failure |
| `core/src/pipeline/analysis.rs` | `tracing::warn!` on `current_exe()` failure |

### Tests added (6 new, 40 total)

- `TracingCapture` helper in `lib.rs::test_support` for capturing tracing events in tests
- Pipeline stage boundary `info!`/ `error!` event verification
- Mutex poison warning capture in `commands.rs`
- `project_dir` happy-path/no-spurious-warning test
- `run()` errors gracefully when `analyze.py` is missing