### PR TITLE
fix: guard export/delete race with button disable + backend existence check

### DIFF
--- a/core/src/commands.rs
+++ b/core/src/commands.rs
@@ -245,7 +245,23 @@ pub fn export_stems(
     dest_dir: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<String>, String> {
+    // Verify the track still exists before touching the filesystem.
+    {
+        let conn = state
+            .db
+            .lock()
+            .map_err(|_| "database unavailable".to_string())?;
+        if db::get_track(&conn, &track_id)
+            .map_err(|e| e.to_string())?
+            .is_none()
+        {
+            return Err("track not found — it may have been deleted".into());
+        }
+    }
     let stems_dir = paths::stems_dir(&state.data_dir, &track_id);
+    if !stems_dir.exists() {
+        return Err("track data no longer available — it may have been deleted".into());
+    }
     let dest = std::path::PathBuf::from(&dest_dir);
 
     let mut exported = Vec::new();

--- a/core/src/commands.rs
+++ b/core/src/commands.rs
@@ -245,7 +245,6 @@ pub fn export_stems(
     dest_dir: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<String>, String> {
-    // Verify the track still exists before touching the filesystem.
     {
         let conn = state
             .db

--- a/ui/lib/TrackList.svelte
+++ b/ui/lib/TrackList.svelte
@@ -382,6 +382,7 @@
                 e.stopPropagation();
                 deleteTrack(track);
               }}
+              disabled={exportingId === track.id || retryingId === track.id}
               title="Delete track">✕</button
             >
           {/if}

--- a/ui/lib/TrackList.svelte
+++ b/ui/lib/TrackList.svelte
@@ -127,6 +127,7 @@
   }
 
   let deleteError = $state("");
+  let deletingId = $state(null);
 
   let retryingId = $state(null);
   let retryError = $state("");
@@ -155,6 +156,7 @@
       },
     );
     if (!ok) return;
+    deletingId = track.id;
     deleteError = "";
     try {
       await invoke("delete_track", { id: track.id });
@@ -164,6 +166,8 @@
       );
     } catch (e) {
       deleteError = String(e);
+    } finally {
+      deletingId = null;
     }
   }
 
@@ -359,7 +363,7 @@
                   e.stopPropagation();
                   exportStems(track);
                 }}
-                disabled={exportingId === track.id}
+                disabled={exportingId === track.id || deletingId === track.id}
               >
                 {exportingId === track.id ? "Exporting…" : "↓ Export stems"}
               </button>
@@ -382,7 +386,9 @@
                 e.stopPropagation();
                 deleteTrack(track);
               }}
-              disabled={exportingId === track.id || retryingId === track.id}
+              disabled={exportingId === track.id ||
+                deletingId === track.id ||
+                retryingId === track.id}
               title="Delete track">✕</button
             >
           {/if}


### PR DESCRIPTION
## Summary

Prevents a theoretical race where a user could click Delete while an Export is in flight, causing the export to fail with a cryptic filesystem error.

## Changes

- **Frontend** (`TrackList.svelte`): Disable Delete button while `exportingId === track.id` or `retryingId === track.id`, matching the existing pattern on the Export button.
- **Backend** (`commands.rs`): `export_stems` now verifies the track still exists in the DB and the stems directory still exists before copying files. Returns a clear error message if either check fails.

Closes #48