### PR TITLE
fix: make playback export consistent with library export

### DIFF
--- a/ui/App.svelte
+++ b/ui/App.svelte
@@ -108,6 +108,10 @@
     screen = "library";
     // keep selectedTrack alive so playhead position is preserved on return
   }
+
+  async function handleExportDone() {
+    await refreshTracks?.();
+  }
 </script>
 
 <div class="app fade-in">
@@ -140,6 +144,7 @@
           track={selectedTrack}
           active={screen === "playback"}
           onBack={closePlayback}
+          onExportDone={handleExportDone}
         />
       {/if}
     </div>
@@ -198,6 +203,43 @@
 
   :global(.fade-in) {
     animation: fade-in 0.15s ease-out both;
+  }
+
+  :global(.open-btn) {
+    padding: 4px 10px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--fg);
+    font-size: 12px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  :global(.open-btn:hover) {
+    border-color: var(--fg-muted);
+    background: var(--bg-button-hover);
+  }
+
+  :global(.export-btn) {
+    padding: 4px 12px;
+    border: 1px solid var(--accent);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--accent);
+    font-size: 12px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  :global(.export-btn:hover:not(:disabled)) {
+    background: var(--accent);
+    color: #fff;
+  }
+
+  :global(.export-btn:disabled) {
+    opacity: 0.5;
+    cursor: default;
   }
 
   :global(body) {

--- a/ui/lib/Playback.svelte
+++ b/ui/lib/Playback.svelte
@@ -10,7 +10,7 @@
     waveformGradientId,
   } from "./playback.helpers.js";
 
-  let { track, active, onBack } = $props();
+  let { track, active, onBack, onExportDone } = $props();
 
   const STEMS = [
     { key: "vocals", label: "Vocals", color: "#4caf72" },
@@ -391,10 +391,20 @@
     exportError = "";
     try {
       await invoke("export_stems", { trackId: track.id, destDir: dest });
+      track.export_path = dest;
+      await onExportDone?.();
     } catch (e) {
       exportError = String(e);
     } finally {
       exportingId = null;
+    }
+  }
+
+  async function openFolder(path) {
+    try {
+      await invoke("open_folder", { path });
+    } catch (e) {
+      exportError = String(e);
     }
   }
 </script>
@@ -633,6 +643,16 @@
         <button class="dismiss-btn" onclick={() => (exportError = "")}>×</button
         >
       </span>
+    {/if}
+    {#if track.export_path}
+      <button
+        class="open-btn"
+        onclick={() => openFolder(track.export_path)}
+        title={track.export_path}
+        disabled={!!exportingId}
+      >
+        Open folder
+      </button>
     {/if}
     <button class="export-btn" onclick={exportStems} disabled={!!exportingId}>
       {exportingId ? "Exporting…" : "↓ Export stems"}
@@ -998,25 +1018,5 @@
     cursor: pointer;
     font-size: 13px;
     padding: 0 0 0 4px;
-  }
-
-  .export-btn {
-    padding: 7px 18px;
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    background: transparent;
-    color: var(--fg);
-    font-size: 13px;
-    cursor: pointer;
-  }
-
-  .export-btn:hover:not(:disabled) {
-    background: var(--bg-button-hover);
-    border-color: var(--fg-muted);
-  }
-
-  .export-btn:disabled {
-    opacity: 0.45;
-    cursor: default;
   }
 </style>

--- a/ui/lib/TrackList.svelte
+++ b/ui/lib/TrackList.svelte
@@ -175,7 +175,7 @@
     try {
       await invoke("open_folder", { path });
     } catch (e) {
-      deleteError = String(e);
+      exportError = String(e);
     }
   }
 
@@ -353,6 +353,7 @@
                     openFolder(track.export_path);
                   }}
                   title={track.export_path}
+                  disabled={exportingId === track.id || deletingId === track.id}
                 >
                   Open folder
                 </button>
@@ -587,43 +588,6 @@
     align-items: center;
     gap: 6px;
     flex-shrink: 0;
-  }
-
-  .export-btn {
-    padding: 4px 12px;
-    border: 1px solid var(--accent);
-    border-radius: 4px;
-    background: transparent;
-    color: var(--accent);
-    font-size: 12px;
-    cursor: pointer;
-    white-space: nowrap;
-  }
-
-  .export-btn:hover:not(:disabled) {
-    background: var(--accent);
-    color: #fff;
-  }
-
-  .export-btn:disabled {
-    opacity: 0.5;
-    cursor: default;
-  }
-
-  .open-btn {
-    padding: 4px 10px;
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    background: transparent;
-    color: var(--fg);
-    font-size: 12px;
-    cursor: pointer;
-    white-space: nowrap;
-  }
-
-  .open-btn:hover {
-    border-color: var(--fg-muted);
-    background: var(--bg-button-hover);
   }
 
   .retry-btn {


### PR DESCRIPTION
Two issues fixed:

1. **Playback export didn't refresh track data** — TrackList called `refreshTracks()` after export to update `track.export_path` and show the "Open folder" button. Playback skipped this. Fixed by threading an `onExportDone` callback from App.svelte that calls `refreshTracks?.()`, plus a direct `track.export_path = dest` mutation for immediate reactivity.

2. **Playback had no "Open folder" button** — TrackList showed one when `track.export_path` was set. Added the same conditional button to the Playback footer, with an `openFolder` function mirroring TrackList's.

**Refactor:** Extracted shared `.open-btn` and `.export-btn` styles into `App.svelte` as `:global()` rules (pattern already used for `body`, `root`, `fade-in`) and removed the identical duplicates from both child components.