### PR TITLE
fix: suppress subprocess console windows on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ dist-ssr
 # Claude Code session data
 .claude/
 
+# Local toolchain pins (asdf/mise) — not everyone uses a version manager
+.tool-versions
+
 # Editor directories and files
 .vscode
 .idea

--- a/core/src/pipeline/bins.rs
+++ b/core/src/pipeline/bins.rs
@@ -1,4 +1,24 @@
+use std::ffi::OsStr;
 use std::path::PathBuf;
+use std::process::Command;
+
+/// Build a `Command` that does not spawn a console window on Windows.
+///
+/// On non-Windows platforms this is just `Command::new`. On Windows the app is
+/// built with `windows_subsystem = "windows"`, which hides the app's own
+/// console but not those of child processes — so each subprocess (yt-dlp,
+/// ffmpeg, ffprobe, demucs) would flash a console window without this flag.
+pub fn command(program: impl AsRef<OsStr>) -> Command {
+    #[cfg_attr(not(windows), allow(unused_mut))]
+    let mut cmd = Command::new(program);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd
+}
 
 /// Resolve a sidecar binary path.
 ///

--- a/core/src/pipeline/download.rs
+++ b/core/src/pipeline/download.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-use std::process::Command;
 
 use super::bins;
 
@@ -10,7 +9,7 @@ pub fn from_youtube(url: &str, dest: &Path) -> Result<(), String> {
         .parent()
         .map(|p| p.to_path_buf())
         .unwrap_or(ffmpeg.clone());
-    let output = Command::new(bins::resolve("yt-dlp"))
+    let output = bins::command(bins::resolve("yt-dlp"))
         .args([
             "--ffmpeg-location",
             ffmpeg_dir.to_str().ok_or("invalid ffmpeg path")?,
@@ -48,7 +47,7 @@ pub fn from_local(src: &Path, dest: &Path) -> Result<(), String> {
     if ext == "wav" {
         std::fs::copy(src, dest).map_err(|e| format!("failed to copy WAV: {e}"))?;
     } else {
-        let output = Command::new(bins::resolve("ffmpeg"))
+        let output = bins::command(bins::resolve("ffmpeg"))
             .args([
                 "-y",
                 "-i",
@@ -77,7 +76,7 @@ pub fn youtube_title(url: &str) -> Option<String> {
         .parent()
         .map(|p| p.to_path_buf())
         .unwrap_or(ffmpeg.clone());
-    let output = Command::new(bins::resolve("yt-dlp"))
+    let output = bins::command(bins::resolve("yt-dlp"))
         .args([
             "--ffmpeg-location",
             ffmpeg_dir.to_str()?,
@@ -113,7 +112,7 @@ pub fn local_title(src: &Path) -> String {
 /// (e.g. format=duration was "N/A"). Returns `Err` for execution failures
 /// — callers should treat this as a non-fatal best-effort and continue.
 pub fn probe_duration_ms(src: &Path) -> Result<Option<i64>, String> {
-    let output = Command::new(bins::resolve("ffprobe"))
+    let output = bins::command(bins::resolve("ffprobe"))
         .args([
             "-v",
             "error",

--- a/core/src/pipeline/stems.rs
+++ b/core/src/pipeline/stems.rs
@@ -1,6 +1,5 @@
 use crate::constants::{DEMUCS_MODEL, STEM_NAMES};
 use std::path::Path;
-use std::process::Command;
 
 /// Run Demucs on `source_wav`, writing 4 stems into `stems_dir`.
 /// `demucs_bin` is the path to the frozen demucs executable.
@@ -24,7 +23,7 @@ pub fn separate(
     let result: Result<(), String> = (|| {
         std::fs::create_dir_all(cache_dir).map_err(|e| format!("mkdir cache_dir: {e}"))?;
 
-        let output = Command::new(demucs_bin)
+        let output = super::bins::command(demucs_bin)
             .args([
                 "--name",
                 DEMUCS_MODEL,


### PR DESCRIPTION
Closes #90

## Why

On the Windows build, the app pops a visible `cmd`-style console window every time it shells out to a helper binary. The first time a user adds a track, console windows flash for **yt-dlp**, **ffmpeg**, **ffprobe**, and **demucs** during the download → stems pipeline — a jarring first impression.

`main.rs` sets `windows_subsystem = "windows"`, but that only hides the app's *own* console; it does nothing for child processes. None of the `Command::new(...)` spawn sites set the `CREATE_NO_WINDOW` (`0x08000000`) creation flag.

## What

- Add `bins::command(program)` — a `Command` builder that applies `CREATE_NO_WINDOW` on Windows and is a plain `Command::new` everywhere else.
- Route the live subprocess spawns through it: `download.rs` (yt-dlp ×2, ffmpeg, ffprobe) and `stems.rs` (demucs). Dropped the now-unused `use std::process::Command` in both.

The macOS-only `xattr` spawn (`setup.rs`) and the stubbed/uninvoked `poetry` spawn (`analysis.rs`) are intentionally left alone.

A second commit gitignores local `.tool-versions` (asdf/mise pins shouldn't be imposed on contributors without a version manager).

## Verification

- `just ci` green on macOS: `cargo fmt --check`, `cargo clippy -D warnings`, 41 Rust tests, Vite build, svelte-check (0 errors), Prettier.
- The `#[cfg(windows)]` branch uses only stdlib (`std::os::windows::process::CommandExt::creation_flags`) and is compiled for real on the `windows-latest` runner in `release.yml`. (Cross-compiling from macOS is blocked by an unrelated C dependency needing the Windows SDK.)
- Behavioural check on Windows (needs a Windows box): add a YouTube track + a local file, confirm no console windows flash during download / WAV conversion / ffprobe / demucs, and stems still land in the library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)