### PR TITLE
fix: ship native arm64 ffmpeg/ffprobe in macOS releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,13 +146,18 @@ jobs:
         run: |
           mkdir -p core/binaries
           # yt-dlp — universal binary, runs natively on both arm64 and x86_64
-          curl -fsSL --retry 3 --retry-all-errors "https://github.com/yt-dlp/yt-dlp/releases/download/${{ env.YT_DLP_VERSION }}/yt-dlp_macos" \
+          curl -fsSL --retry 3 --retry-all-errors --max-time 120 "https://github.com/yt-dlp/yt-dlp/releases/download/${{ env.YT_DLP_VERSION }}/yt-dlp_macos" \
             -o core/binaries/yt-dlp-${{ matrix.target }}
           chmod +x core/binaries/yt-dlp-${{ matrix.target }}
           # ffmpeg + ffprobe — native static builds per arch, so no Rosetta dependency
           # (which macOS now warns about on Apple Silicon).
-          #   x86_64: evermeet.cx  |  arm64: osxexperts.net (zip name drops the dots)
+          #   x86_64: evermeet.cx  |  arm64: osxexperts.net
           if [ "${{ matrix.target }}" = "aarch64-apple-darwin" ]; then
+            # osxexperts.net names arm64 zips by version with the dots stripped
+            # (7.1.1 -> 711). The scheme is an informal convention and dot-stripping
+            # can theoretically collide (e.g. 7.1.0 vs 7.10 -> 710), so verify the
+            # exact URL by hand whenever FFMPEG_MACOS_VERSION is bumped. The site is
+            # also bandwidth-throttled, hence the generous --max-time below.
             ver_nodots="${FFMPEG_MACOS_VERSION//./}"
             ffmpeg_url="https://www.osxexperts.net/ffmpeg${ver_nodots}arm.zip"
             ffprobe_url="https://www.osxexperts.net/ffprobe${ver_nodots}arm.zip"
@@ -160,7 +165,6 @@ jobs:
             ffmpeg_url="https://evermeet.cx/ffmpeg/ffmpeg-${FFMPEG_MACOS_VERSION}.zip"
             ffprobe_url="https://evermeet.cx/ffmpeg/ffprobe-${FFMPEG_MACOS_VERSION}.zip"
           fi
-          # osxexperts.net is bandwidth-throttled, so allow a generous timeout + retries.
           curl -fsSL --retry 4 --retry-all-errors --retry-delay 5 --max-time 300 "$ffmpeg_url" -o ffmpeg.zip
           curl -fsSL --retry 4 --retry-all-errors --retry-delay 5 --max-time 300 "$ffprobe_url" -o ffprobe.zip
           unzip -o ffmpeg.zip ffmpeg -d .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   YT_DLP_VERSION: "2026.03.17"     # https://github.com/yt-dlp/yt-dlp/releases
-  FFMPEG_MACOS_VERSION: "7.1.1"    # https://evermeet.cx/ffmpeg/ (check for latest release zip name)
+  FFMPEG_MACOS_VERSION: "7.1.1"    # x86_64: https://evermeet.cx/ffmpeg/ | arm64: https://www.osxexperts.net/ (zip name drops the dots, e.g. 711)
   FFMPEG_LINUX_VERSION: "6.1"      # https://ffbinaries.com/api/v1/versions
   FFMPEG_WIN_VERSION: "7.1"  # pins ffmpeg minor version; uses BtbN "latest" release tag (stable filenames per minor version)
 
@@ -146,17 +146,39 @@ jobs:
         run: |
           mkdir -p core/binaries
           # yt-dlp — universal binary, runs natively on both arm64 and x86_64
-          curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/download/${{ env.YT_DLP_VERSION }}/yt-dlp_macos" \
+          curl -fsSL --retry 3 --retry-all-errors "https://github.com/yt-dlp/yt-dlp/releases/download/${{ env.YT_DLP_VERSION }}/yt-dlp_macos" \
             -o core/binaries/yt-dlp-${{ matrix.target }}
           chmod +x core/binaries/yt-dlp-${{ matrix.target }}
-          # ffmpeg + ffprobe — evermeet.cx x86_64 static builds.
-          # No public static arm64 build exists; x86_64 runs via Rosetta 2 on Apple Silicon.
-          curl -fsSL "https://evermeet.cx/ffmpeg/ffmpeg-${{ env.FFMPEG_MACOS_VERSION }}.zip" -o ffmpeg.zip
-          curl -fsSL "https://evermeet.cx/ffmpeg/ffprobe-${{ env.FFMPEG_MACOS_VERSION }}.zip" -o ffprobe.zip
+          # ffmpeg + ffprobe — native static builds per arch, so no Rosetta dependency
+          # (which macOS now warns about on Apple Silicon).
+          #   x86_64: evermeet.cx  |  arm64: osxexperts.net (zip name drops the dots)
+          if [ "${{ matrix.target }}" = "aarch64-apple-darwin" ]; then
+            ver_nodots="${FFMPEG_MACOS_VERSION//./}"
+            ffmpeg_url="https://www.osxexperts.net/ffmpeg${ver_nodots}arm.zip"
+            ffprobe_url="https://www.osxexperts.net/ffprobe${ver_nodots}arm.zip"
+          else
+            ffmpeg_url="https://evermeet.cx/ffmpeg/ffmpeg-${FFMPEG_MACOS_VERSION}.zip"
+            ffprobe_url="https://evermeet.cx/ffmpeg/ffprobe-${FFMPEG_MACOS_VERSION}.zip"
+          fi
+          # osxexperts.net is bandwidth-throttled, so allow a generous timeout + retries.
+          curl -fsSL --retry 4 --retry-all-errors --retry-delay 5 --max-time 300 "$ffmpeg_url" -o ffmpeg.zip
+          curl -fsSL --retry 4 --retry-all-errors --retry-delay 5 --max-time 300 "$ffprobe_url" -o ffprobe.zip
           unzip -o ffmpeg.zip ffmpeg -d .
           unzip -o ffprobe.zip ffprobe -d .
           cp ffmpeg core/binaries/ffmpeg-${{ matrix.target }}
           cp ffprobe core/binaries/ffprobe-${{ matrix.target }}
+          # Fail the build if the bundled arch doesn't match the target (belt-and-suspenders).
+          case "${{ matrix.target }}" in
+            aarch64-apple-darwin) want=arm64 ;;
+            x86_64-apple-darwin)  want=x86_64 ;;
+          esac
+          for bin in ffmpeg ffprobe; do
+            got=$(lipo -archs "core/binaries/${bin}-${{ matrix.target }}")
+            if [ "$got" != "$want" ]; then
+              echo "::error::${bin} arch mismatch: expected ${want}, got '${got}'"
+              exit 1
+            fi
+          done
 
       - name: Download sidecar binaries (Linux)
         if: matrix.os == 'ubuntu-22.04'


### PR DESCRIPTION
## Why

macOS shows a **"Support Ending for Intel-Based Apps"** notification for Wavesplit on Apple Silicon. The `.app` bundle's own binary, `yt-dlp`, and the runtime-downloaded Demucs sidecar are all arm64 — but the bundled **`ffmpeg` and `ffprobe` are Intel-only (x86_64)**, so they run via Rosetta and trip the warning.

Root cause: the macOS sidecar step in `release.yml` downloaded x86_64-only builds from evermeet.cx and copied them into **both** the Intel and Apple Silicon DMGs. The arm64 release shipped Intel ffmpeg/ffprobe.

## What

Make the macOS sidecar step architecture-aware:

- **arm64** (`aarch64-apple-darwin`): native static builds from osxexperts.net
- **x86_64** (`x86_64-apple-darwin`): evermeet.cx builds (unchanged)
- Added `curl` retries + a 300s timeout — osxexperts.net is bandwidth-throttled and intermittently slow.
- Added a `lipo -archs` guard that **fails the release build** if a bundled binary's arch doesn't match its target, so this can't silently regress.

## Verification

- Downloaded and confirmed both osxexperts arm64 zips are genuine `ffmpeg`/`ffprobe` 7.1.1 arm64 builds (`lipo -info` → `arm64`).
- `actionlint` clean on the edited step.
- `just ci` passed.

## Notes

- Only affects **future** releases — existing installs keep the warning until updated.
- No code paths changed; this is release packaging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)