### PR TITLE
fix: secure track filesystem operations against path traversal

### DIFF
--- a/core/src/commands.rs
+++ b/core/src/commands.rs
@@ -90,7 +90,7 @@ pub struct AddTrackResult {
     pub duplicate: bool,
 }
 
-#[derive(serde::Serialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct StemPaths {
     pub vocals: String,
     pub drums: String,
@@ -103,6 +103,19 @@ pub fn get_stem_paths(
     track_id: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<StemPaths, String> {
+    let track_id = paths::parse_track_id(&track_id)?;
+    {
+        let conn = state
+            .db
+            .lock()
+            .map_err(|_| "database unavailable".to_string())?;
+        if db::get_track(&conn, &track_id)
+            .map_err(|e| e.to_string())?
+            .is_none()
+        {
+            return Err("track not found".into());
+        }
+    }
     let stems = paths::stems_dir(&state.data_dir, &track_id);
     let p = |name: &str| stems.join(name).to_string_lossy().into_owned();
     Ok(StemPaths {
@@ -151,39 +164,78 @@ pub async fn add_track_youtube(
     })
 }
 
+// Keep in sync with ACCEPTED_AUDIO_EXTENSIONS in ui/lib/importTrack.ts.
+const ACCEPTED_LOCAL_EXTENSIONS: [&str; 6] = ["mp3", "wav", "flac", "m4a", "aac", "ogg"];
+
+/// Canonicalizes and validates a caller-supplied local import path. Canonicalization requires
+/// the path to exist on disk, which rejects protocol-like strings (`http://...`) and traversal
+/// sequences that don't resolve to a real file; it also resolves symlinks, so the extension and
+/// regular-file checks below apply to the real target rather than a symlink pointing elsewhere.
+fn validate_local_source(raw: &str) -> Result<std::path::PathBuf, String> {
+    if raw.is_empty() || raw.contains("://") {
+        return Err("invalid local file path".to_string());
+    }
+    let canonical = std::path::Path::new(raw)
+        .canonicalize()
+        .map_err(|_| "file not found".to_string())?;
+    if !canonical.is_file() {
+        return Err("not a regular file".to_string());
+    }
+    let ext = canonical
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+    if !ACCEPTED_LOCAL_EXTENSIONS.contains(&ext.as_str()) {
+        return Err(format!("unsupported file type: .{ext}"));
+    }
+    Ok(canonical)
+}
+
 #[tauri::command]
-pub async fn add_track_local(
+pub async fn add_track_local<R: tauri::Runtime>(
     path: String,
-    app: AppHandle,
+    app: AppHandle<R>,
     state: tauri::State<'_, AppState>,
 ) -> Result<AddTrackResult, String> {
+    let canonical = validate_local_source(&path)?;
+    let canonical_str = canonical.to_string_lossy().into_owned();
     {
         let conn = state
             .db
             .lock()
             .map_err(|_| "database unavailable".to_string())?;
-        if let Some(existing) = db::find_by_path(&conn, &path).map_err(|e| e.to_string())? {
+        if let Some(existing) =
+            db::find_by_path(&conn, &canonical_str).map_err(|e| e.to_string())?
+        {
             return Ok(AddTrackResult {
                 id: existing.id,
                 duplicate: true,
             });
         }
     }
-    let src = std::path::PathBuf::from(&path);
-    let title = pipeline::download::local_title(&src);
-    let id = add_track(Source::Local(src), title, None, Some(path), app, state).await?;
+    let title = pipeline::download::local_title(&canonical);
+    let id = add_track(
+        Source::Local(canonical),
+        title,
+        None,
+        Some(canonical_str),
+        app,
+        state,
+    )
+    .await?;
     Ok(AddTrackResult {
         id,
         duplicate: false,
     })
 }
 
-async fn add_track(
+async fn add_track<R: tauri::Runtime>(
     source: Source,
     title: String,
     source_url: Option<String>,
     source_path: Option<String>,
-    app: AppHandle,
+    app: AppHandle<R>,
     state: tauri::State<'_, AppState>,
 ) -> Result<String, String> {
     let id = Uuid::new_v4().to_string();
@@ -245,6 +297,7 @@ pub fn export_stems(
     dest_dir: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<String>, String> {
+    let track_id = paths::parse_track_id(&track_id)?;
     {
         let conn = state
             .db
@@ -301,11 +354,17 @@ pub fn update_track_meta(
     artist: Option<String>,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
+    let id = paths::parse_track_id(&id)?;
     let conn = state
         .db
         .lock()
         .map_err(|_| "database unavailable".to_string())?;
-    db::update_track_meta(&conn, &id, &title, artist.as_deref()).map_err(|e| e.to_string())
+    let rows =
+        db::update_track_meta(&conn, &id, &title, artist.as_deref()).map_err(|e| e.to_string())?;
+    if rows == 0 {
+        return Err("track not found".to_string());
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -324,6 +383,7 @@ pub async fn retry_track<R: tauri::Runtime>(
     app: AppHandle<R>,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
+    let id = paths::parse_track_id(&id)?;
     // Don't retry if already running
     if state
         .tasks
@@ -473,16 +533,17 @@ mod tests {
             tasks: Arc::clone(&tasks),
         };
 
+        let track_id = "22222222-2222-2222-2222-222222222222";
         tasks
             .lock()
             .unwrap()
-            .insert("test-retry-id".to_string(), CancellationToken::new());
+            .insert(track_id.to_string(), CancellationToken::new());
 
         let app = mock_app();
         app.manage(app_state);
         let state = app.state::<AppState>();
 
-        let result = retry_track("test-retry-id".to_string(), app.handle().clone(), state).await;
+        let result = retry_track(track_id.to_string(), app.handle().clone(), state).await;
 
         assert!(result.is_err());
         assert!(
@@ -554,12 +615,13 @@ mod tests {
             tasks: Arc::clone(&tasks),
         };
 
+        let track_id = "33333333-3333-3333-3333-333333333333";
         {
             let conn = db.lock().unwrap();
             crate::db::insert_track(
                 &conn,
                 &crate::db::Track {
-                    id: "test-retry-spawn".to_string(),
+                    id: track_id.to_string(),
                     title: "Retry Test".to_string(),
                     source_type: "youtube".to_string(),
                     source_url: Some("https://youtube.com/watch?v=test".to_string()),
@@ -582,18 +644,18 @@ mod tests {
         app.manage(app_state);
         let state = app.state::<AppState>();
 
-        let result = retry_track("test-retry-spawn".to_string(), app.handle().clone(), state).await;
+        let result = retry_track(track_id.to_string(), app.handle().clone(), state).await;
 
         assert!(result.is_ok(), "retry should succeed: {:?}", result.err());
 
         assert!(
-            tasks.lock().unwrap().contains_key("test-retry-spawn"),
+            tasks.lock().unwrap().contains_key(track_id),
             "pipeline task should be spawned"
         );
 
         let start = std::time::Instant::now();
         let timeout = std::time::Duration::from_secs(5);
-        while tasks.lock().unwrap().contains_key("test-retry-spawn") {
+        while tasks.lock().unwrap().contains_key(track_id) {
             if start.elapsed() > timeout {
                 panic!("pipeline task did not complete within timeout");
             }
@@ -625,5 +687,209 @@ mod tests {
             !tasks.lock().unwrap().contains_key(&track_id),
             "task entry should be removed even after a panic"
         );
+    }
+
+    fn mem_state() -> AppState {
+        AppState {
+            db: Arc::new(Mutex::new(
+                crate::db::open(std::path::Path::new(":memory:")).unwrap(),
+            )),
+            data_dir: std::path::PathBuf::from("/tmp"),
+            demucs_dir: std::path::PathBuf::from("/tmp"),
+            tasks: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    #[test]
+    fn get_stem_paths_rejects_malformed_id() {
+        let app = mock_app();
+        app.manage(mem_state());
+        let result = get_stem_paths("../../etc".to_string(), app.state::<AppState>());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_stem_paths_rejects_unknown_track() {
+        let app = mock_app();
+        app.manage(mem_state());
+        let id = "44444444-4444-4444-4444-444444444444".to_string();
+        let result = get_stem_paths(id, app.state::<AppState>());
+        assert!(result.unwrap_err().contains("not found"));
+    }
+
+    #[test]
+    fn get_stem_paths_returns_paths_for_existing_track() {
+        let app = mock_app();
+        app.manage(mem_state());
+        let id = "55555555-5555-5555-5555-555555555555";
+        {
+            let state = app.state::<AppState>();
+            let conn = state.db.lock().unwrap();
+            let track = crate::db::Track {
+                id: id.to_string(),
+                title: "T".to_string(),
+                source_type: "local".to_string(),
+                source_url: None,
+                source_path: None,
+                created_at: "2024-01-01T00:00:00Z".to_string(),
+                sort_order: 1,
+                duration_ms: None,
+                status_download: "done".to_string(),
+                status_stems: "done".to_string(),
+                status_analysis: "done".to_string(),
+                error_message: None,
+                export_path: None,
+                artist: None,
+            };
+            crate::db::insert_track(&conn, &track).unwrap();
+        }
+        let result = get_stem_paths(id.to_string(), app.state::<AppState>()).unwrap();
+        assert!(result.bass.ends_with("bass.wav"));
+        assert!(result.bass.contains(id));
+    }
+
+    #[test]
+    fn export_stems_rejects_malformed_id() {
+        let app = mock_app();
+        app.manage(mem_state());
+        let result = export_stems(
+            "/etc/passwd".to_string(),
+            std::env::temp_dir().to_string_lossy().into_owned(),
+            app.state::<AppState>(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_track_meta_rejects_malformed_id() {
+        let app = mock_app();
+        app.manage(mem_state());
+        let result = update_track_meta(
+            "../../evil".to_string(),
+            "Title".to_string(),
+            None,
+            app.state::<AppState>(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_track_meta_rejects_unknown_track() {
+        let app = mock_app();
+        app.manage(mem_state());
+        let id = "66666666-6666-6666-6666-666666666666".to_string();
+        let result = update_track_meta(id, "Title".to_string(), None, app.state::<AppState>());
+        assert!(result.unwrap_err().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn retry_track_rejects_malformed_id() {
+        let app = mock_app();
+        app.manage(mem_state());
+        let state = app.state::<AppState>();
+        let result = retry_track("../../evil".to_string(), app.handle().clone(), state).await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_local_source_rejects_missing_file() {
+        assert!(validate_local_source("/nonexistent/wavesplit-test/does-not-exist.wav").is_err());
+    }
+
+    #[test]
+    fn validate_local_source_rejects_protocol_like_input() {
+        assert!(validate_local_source("http://example.com/track.mp3").is_err());
+    }
+
+    #[test]
+    fn validate_local_source_rejects_directory() {
+        let dir = std::env::temp_dir();
+        assert!(validate_local_source(&dir.to_string_lossy()).is_err());
+    }
+
+    #[test]
+    fn validate_local_source_rejects_disallowed_extension() {
+        let path = std::env::temp_dir().join("wavesplit-test-validate-local-source.exe");
+        std::fs::write(&path, b"not audio").unwrap();
+        let result = validate_local_source(&path.to_string_lossy());
+        let _ = std::fs::remove_file(&path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_local_source_accepts_and_canonicalizes_valid_file() {
+        let path = std::env::temp_dir().join("wavesplit-test-validate-local-source.wav");
+        std::fs::write(&path, b"not real audio, just bytes").unwrap();
+        let expected = path.canonicalize().unwrap();
+        let result = validate_local_source(&path.to_string_lossy());
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(result.unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn add_track_local_rejects_disallowed_extension() {
+        let bad_file = std::env::temp_dir().join("wavesplit-test-add-track-local.exe");
+        std::fs::write(&bad_file, b"not audio").unwrap();
+
+        let app = mock_app();
+        app.manage(mem_state());
+        let state = app.state::<AppState>();
+
+        let result = add_track_local(
+            bad_file.to_string_lossy().into_owned(),
+            app.handle().clone(),
+            state,
+        )
+        .await;
+        let _ = std::fs::remove_file(&bad_file);
+
+        assert!(result.is_err());
+        let state = app.state::<AppState>();
+        let conn = state.db.lock().unwrap();
+        assert!(
+            crate::db::list_tracks(&conn).unwrap().is_empty(),
+            "no track row should be inserted for a rejected import"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_track_local_canonicalizes_and_dedupes_by_real_path() {
+        let wav_file = std::env::temp_dir().join("wavesplit-test-add-track-local-dedupe.wav");
+        std::fs::write(&wav_file, b"not real audio, just bytes").unwrap();
+        let canonical = wav_file.canonicalize().unwrap();
+
+        let app = mock_app();
+        app.manage(mem_state());
+
+        let first = add_track_local(
+            wav_file.to_string_lossy().into_owned(),
+            app.handle().clone(),
+            app.state::<AppState>(),
+        )
+        .await
+        .expect("first import should succeed");
+        assert!(!first.duplicate);
+
+        let second = add_track_local(
+            wav_file.to_string_lossy().into_owned(),
+            app.handle().clone(),
+            app.state::<AppState>(),
+        )
+        .await
+        .expect("second import should be detected as duplicate");
+        assert!(second.duplicate);
+        assert_eq!(second.id, first.id);
+
+        {
+            let state = app.state::<AppState>();
+            let conn = state.db.lock().unwrap();
+            let stored = crate::db::get_track(&conn, &first.id).unwrap().unwrap();
+            assert_eq!(
+                stored.source_path.as_deref(),
+                Some(canonical.to_string_lossy().as_ref())
+            );
+        }
+
+        let _ = std::fs::remove_file(&wav_file);
     }
 }

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -99,12 +99,11 @@ pub fn update_track_meta(
     id: &str,
     title: &str,
     artist: Option<&str>,
-) -> Result<()> {
+) -> Result<usize> {
     conn.execute(
         "UPDATE tracks SET title = ?1, artist = ?2 WHERE id = ?3",
         params![title, artist, id],
-    )?;
-    Ok(())
+    )
 }
 
 pub fn list_tracks(conn: &Connection) -> Result<Vec<Track>> {
@@ -151,9 +150,8 @@ pub fn update_status(
     Ok(())
 }
 
-pub fn delete_track(conn: &Connection, id: &str) -> Result<()> {
-    conn.execute("DELETE FROM tracks WHERE id = ?1", params![id])?;
-    Ok(())
+pub fn delete_track(conn: &Connection, id: &str) -> Result<usize> {
+    conn.execute("DELETE FROM tracks WHERE id = ?1", params![id])
 }
 
 /// On startup: reset any track with a pending stage to error so the UI can offer retry.
@@ -411,7 +409,10 @@ mod tests {
     fn update_track_meta_changes_title_and_artist() {
         let conn = open_mem();
         insert_track(&conn, &sample_track("t9")).unwrap();
-        update_track_meta(&conn, "t9", "New Title", Some("New Artist")).unwrap();
+        assert_eq!(
+            update_track_meta(&conn, "t9", "New Title", Some("New Artist")).unwrap(),
+            1
+        );
         let track = get_track(&conn, "t9").unwrap().unwrap();
         assert_eq!(track.title, "New Title");
         assert_eq!(track.artist.as_deref(), Some("New Artist"));
@@ -485,8 +486,23 @@ mod tests {
         let conn = open_mem();
         insert_track(&conn, &sample_track("t12")).unwrap();
         assert!(get_track(&conn, "t12").unwrap().is_some());
-        delete_track(&conn, "t12").unwrap();
+        assert_eq!(delete_track(&conn, "t12").unwrap(), 1);
         assert!(get_track(&conn, "t12").unwrap().is_none());
+    }
+
+    #[test]
+    fn delete_track_returns_zero_for_missing_row() {
+        let conn = open_mem();
+        assert_eq!(delete_track(&conn, "nonexistent").unwrap(), 0);
+    }
+
+    #[test]
+    fn update_track_meta_returns_zero_for_missing_row() {
+        let conn = open_mem();
+        assert_eq!(
+            update_track_meta(&conn, "nonexistent", "Title", None).unwrap(),
+            0
+        );
     }
 
     #[test]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -54,12 +54,19 @@ fn delete_track(id: String, state: tauri::State<AppState>) -> Result<(), String>
         return Err("track not found".to_string());
     }
     let track_dir = paths::track_dir(&state.data_dir, &id);
-    // If a symlink was somehow planted at the track dir path, unlink it directly rather than
-    // recursing through it — remove_dir_all should never follow a top-level symlink out of
-    // the tracks root.
+    // If a symlink was somehow planted at the track dir path, unlink the entry itself rather
+    // than recursing through it — remove_dir_all should never follow a top-level symlink out
+    // of the tracks root. On Windows, directory-type reparse points must be removed via
+    // RemoveDirectoryW (`remove_dir`), not DeleteFileW (`remove_file`); symlink_metadata's
+    // `is_dir()` reports that without following the link (on Unix a symlink never reports as
+    // a dir here, so this always falls through to `remove_file` there, which is correct).
     match std::fs::symlink_metadata(&track_dir) {
         Ok(meta) if meta.file_type().is_symlink() => {
-            std::fs::remove_file(&track_dir).map_err(|e| e.to_string())?;
+            if meta.is_dir() {
+                std::fs::remove_dir(&track_dir).map_err(|e| e.to_string())?;
+            } else {
+                std::fs::remove_file(&track_dir).map_err(|e| e.to_string())?;
+            }
         }
         Ok(_) => std::fs::remove_dir_all(&track_dir).map_err(|e| e.to_string())?,
         Err(_) => {}
@@ -381,6 +388,79 @@ mod tests {
         assert!(
             !track_dir.exists(),
             "symlink at the track dir path should be removed"
+        );
+        assert!(
+            marker.exists(),
+            "the symlink target's contents must not be touched"
+        );
+
+        let _ = std::fs::remove_dir_all(&data_dir);
+        let _ = std::fs::remove_dir_all(&target_dir);
+    }
+
+    // Windows distinguishes directory-type reparse points from file symlinks at the deletion
+    // API level (RemoveDirectoryW vs DeleteFileW); this mirrors the Unix test above using
+    // `symlink_dir` to make sure that distinction is handled.
+    #[cfg(windows)]
+    #[test]
+    fn delete_track_unlinks_directory_symlink_without_following_it() {
+        use std::os::windows::fs::symlink_dir;
+
+        let data_dir = temp_data_dir("symlink-escape-windows");
+        let id = "99999999-9999-9999-9999-999999999998";
+
+        let target_dir = std::env::temp_dir().join(format!(
+            "wavesplit-lib-test-symlink-target-windows-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let marker = target_dir.join("marker.txt");
+        std::fs::write(&marker, b"do not delete me").unwrap();
+
+        let track_dir = data_dir.join("tracks").join(id);
+        // Directory symlink creation requires developer mode or admin privileges on Windows;
+        // skip rather than fail the suite in restricted CI/dev environments.
+        if symlink_dir(&target_dir, &track_dir).is_err() {
+            let _ = std::fs::remove_dir_all(&data_dir);
+            let _ = std::fs::remove_dir_all(&target_dir);
+            return;
+        }
+
+        let app = mock_app();
+        app.manage(state_with_data_dir(data_dir.clone()));
+        {
+            let state = app.state::<AppState>();
+            let conn = state.db.lock().unwrap();
+            db::insert_track(
+                &conn,
+                &db::Track {
+                    id: id.to_string(),
+                    title: "T".to_string(),
+                    source_type: "local".to_string(),
+                    source_url: None,
+                    source_path: None,
+                    created_at: "2024-01-01T00:00:00Z".to_string(),
+                    sort_order: 1,
+                    duration_ms: None,
+                    status_download: "done".to_string(),
+                    status_stems: "done".to_string(),
+                    status_analysis: "done".to_string(),
+                    error_message: None,
+                    export_path: None,
+                    artist: None,
+                },
+            )
+            .unwrap();
+        }
+
+        let result = delete_track(id.to_string(), app.state::<AppState>());
+        assert!(result.is_ok(), "{:?}", result.err());
+        assert!(
+            !track_dir.exists(),
+            "directory symlink at the track dir path should be removed"
         );
         assert!(
             marker.exists(),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -37,6 +37,7 @@ fn list_tracks(state: tauri::State<AppState>) -> Result<Vec<db::Track>, String> 
 
 #[tauri::command]
 fn delete_track(id: String, state: tauri::State<AppState>) -> Result<(), String> {
+    let id = paths::parse_track_id(&id)?;
     // Cancel any in-flight pipeline task before touching the filesystem.
     if let Ok(mut tasks) = state.tasks.lock() {
         if let Some(token) = tasks.remove(&id) {
@@ -47,11 +48,21 @@ fn delete_track(id: String, state: tauri::State<AppState>) -> Result<(), String>
         .db
         .lock()
         .map_err(|_| "database unavailable".to_string())?;
-    db::delete_track(&conn, &id).map_err(|e| e.to_string())?;
+    let rows = db::delete_track(&conn, &id).map_err(|e| e.to_string())?;
     drop(conn);
+    if rows == 0 {
+        return Err("track not found".to_string());
+    }
     let track_dir = paths::track_dir(&state.data_dir, &id);
-    if track_dir.exists() {
-        std::fs::remove_dir_all(&track_dir).map_err(|e| e.to_string())?;
+    // If a symlink was somehow planted at the track dir path, unlink it directly rather than
+    // recursing through it — remove_dir_all should never follow a top-level symlink out of
+    // the tracks root.
+    match std::fs::symlink_metadata(&track_dir) {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            std::fs::remove_file(&track_dir).map_err(|e| e.to_string())?;
+        }
+        Ok(_) => std::fs::remove_dir_all(&track_dir).map_err(|e| e.to_string())?,
+        Err(_) => {}
     }
     Ok(())
 }
@@ -206,5 +217,177 @@ pub(crate) mod test_support {
             let mut events = self.capture.events.lock().unwrap();
             events.push((level, visitor.0));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tauri::{test::mock_app, Manager};
+
+    fn temp_data_dir(label: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("wavesplit-lib-test-{label}-{nanos}"));
+        std::fs::create_dir_all(dir.join("tracks")).unwrap();
+        dir
+    }
+
+    fn state_with_data_dir(data_dir: std::path::PathBuf) -> AppState {
+        AppState {
+            db: Arc::new(Mutex::new(
+                db::open(std::path::Path::new(":memory:")).unwrap(),
+            )),
+            data_dir,
+            demucs_dir: std::path::PathBuf::from("/tmp"),
+            tasks: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    #[test]
+    fn delete_track_rejects_traversal_id() {
+        let data_dir = temp_data_dir("traversal");
+        let app = mock_app();
+        app.manage(state_with_data_dir(data_dir.clone()));
+        let result = delete_track("../../evil".to_string(), app.state::<AppState>());
+        assert!(result.is_err());
+        assert!(
+            data_dir.join("tracks").read_dir().unwrap().next().is_none(),
+            "tracks dir should be untouched"
+        );
+        let _ = std::fs::remove_dir_all(&data_dir);
+    }
+
+    #[test]
+    fn delete_track_rejects_absolute_path_id() {
+        let data_dir = temp_data_dir("abs-path");
+        let app = mock_app();
+        app.manage(state_with_data_dir(data_dir.clone()));
+        let result = delete_track("/etc/passwd".to_string(), app.state::<AppState>());
+        assert!(result.is_err());
+        let _ = std::fs::remove_dir_all(&data_dir);
+    }
+
+    #[test]
+    fn delete_track_returns_not_found_for_unknown_uuid() {
+        let data_dir = temp_data_dir("unknown-uuid");
+        let app = mock_app();
+        app.manage(state_with_data_dir(data_dir.clone()));
+        let id = "77777777-7777-7777-7777-777777777777".to_string();
+        let result = delete_track(id, app.state::<AppState>());
+        assert!(result.unwrap_err().contains("not found"));
+        let _ = std::fs::remove_dir_all(&data_dir);
+    }
+
+    #[test]
+    fn delete_track_removes_existing_track() {
+        let data_dir = temp_data_dir("removes-existing");
+        let id = "88888888-8888-8888-8888-888888888888";
+        let track_dir = data_dir.join("tracks").join(id);
+        std::fs::create_dir_all(&track_dir).unwrap();
+        std::fs::write(track_dir.join("source.wav"), b"stub").unwrap();
+
+        let app = mock_app();
+        app.manage(state_with_data_dir(data_dir.clone()));
+        {
+            let state = app.state::<AppState>();
+            let conn = state.db.lock().unwrap();
+            db::insert_track(
+                &conn,
+                &db::Track {
+                    id: id.to_string(),
+                    title: "T".to_string(),
+                    source_type: "local".to_string(),
+                    source_url: None,
+                    source_path: None,
+                    created_at: "2024-01-01T00:00:00Z".to_string(),
+                    sort_order: 1,
+                    duration_ms: None,
+                    status_download: "done".to_string(),
+                    status_stems: "done".to_string(),
+                    status_analysis: "done".to_string(),
+                    error_message: None,
+                    export_path: None,
+                    artist: None,
+                },
+            )
+            .unwrap();
+        }
+
+        let result = delete_track(id.to_string(), app.state::<AppState>());
+        assert!(result.is_ok(), "{:?}", result.err());
+        assert!(!track_dir.exists());
+        {
+            let state = app.state::<AppState>();
+            let conn = state.db.lock().unwrap();
+            assert!(db::get_track(&conn, id).unwrap().is_none());
+        }
+        let _ = std::fs::remove_dir_all(&data_dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn delete_track_unlinks_symlink_without_following_it() {
+        use std::os::unix::fs::symlink;
+
+        let data_dir = temp_data_dir("symlink-escape");
+        let id = "99999999-9999-9999-9999-999999999999";
+
+        let target_dir = std::env::temp_dir().join(format!(
+            "wavesplit-lib-test-symlink-target-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let marker = target_dir.join("marker.txt");
+        std::fs::write(&marker, b"do not delete me").unwrap();
+
+        let track_dir = data_dir.join("tracks").join(id);
+        symlink(&target_dir, &track_dir).unwrap();
+
+        let app = mock_app();
+        app.manage(state_with_data_dir(data_dir.clone()));
+        {
+            let state = app.state::<AppState>();
+            let conn = state.db.lock().unwrap();
+            db::insert_track(
+                &conn,
+                &db::Track {
+                    id: id.to_string(),
+                    title: "T".to_string(),
+                    source_type: "local".to_string(),
+                    source_url: None,
+                    source_path: None,
+                    created_at: "2024-01-01T00:00:00Z".to_string(),
+                    sort_order: 1,
+                    duration_ms: None,
+                    status_download: "done".to_string(),
+                    status_stems: "done".to_string(),
+                    status_analysis: "done".to_string(),
+                    error_message: None,
+                    export_path: None,
+                    artist: None,
+                },
+            )
+            .unwrap();
+        }
+
+        let result = delete_track(id.to_string(), app.state::<AppState>());
+        assert!(result.is_ok(), "{:?}", result.err());
+        assert!(
+            !track_dir.exists(),
+            "symlink at the track dir path should be removed"
+        );
+        assert!(
+            marker.exists(),
+            "the symlink target's contents must not be touched"
+        );
+
+        let _ = std::fs::remove_dir_all(&data_dir);
+        let _ = std::fs::remove_dir_all(&target_dir);
     }
 }

--- a/core/src/paths.rs
+++ b/core/src/paths.rs
@@ -1,5 +1,19 @@
 use std::path::{Path, PathBuf};
 
+/// The only track-id shape the app ever mints is a UUID (`Uuid::new_v4()` in `add_track`),
+/// so this is both a format check and a path-traversal guard: a well-formed UUID string can
+/// never contain `/`, `..`, or an absolute-path prefix. Returns the canonical (lowercase,
+/// hyphenated) form so callers can't be fooled by e.g. uppercase-hex variants of a real id
+/// mismatching the lowercase form stored in the DB/on disk.
+///
+/// Every Tauri command that accepts an id/track_id from the frontend must call this first and
+/// use the returned normalized string for everything downstream (DB calls, path joins).
+pub fn parse_track_id(raw: &str) -> Result<String, String> {
+    uuid::Uuid::parse_str(raw)
+        .map(|u| u.to_string())
+        .map_err(|_| "invalid track id".to_string())
+}
+
 pub fn track_dir(data_dir: &Path, id: &str) -> PathBuf {
     data_dir.join("tracks").join(id)
 }
@@ -59,6 +73,43 @@ mod tests {
         let base = stems_dir(Path::new(DATA), "abc");
         for stem in crate::constants::STEM_NAMES {
             assert_eq!(base.join(format!("{stem}.wav")).parent().unwrap(), base);
+        }
+    }
+
+    #[test]
+    fn parse_track_id_accepts_valid_uuid() {
+        assert_eq!(
+            parse_track_id("550e8400-e29b-41d4-a716-446655440000").unwrap(),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+    }
+
+    #[test]
+    fn parse_track_id_normalizes_case() {
+        assert_eq!(
+            parse_track_id("550E8400-E29B-41D4-A716-446655440000").unwrap(),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+    }
+
+    #[test]
+    fn parse_track_id_rejects_traversal_and_absolute_paths() {
+        assert!(parse_track_id("../../etc").is_err());
+        assert!(parse_track_id("/etc/passwd").is_err());
+        assert!(parse_track_id("").is_err());
+        assert!(parse_track_id("not-a-uuid").is_err());
+    }
+
+    #[test]
+    fn track_dir_stays_direct_child_of_tracks_root_for_any_valid_id() {
+        let data_dir = Path::new(DATA);
+        for raw in [
+            "550e8400-e29b-41d4-a716-446655440000",
+            "550E8400-E29B-41D4-A716-446655440000",
+        ] {
+            let id = parse_track_id(raw).unwrap();
+            let dir = track_dir(data_dir, &id);
+            assert_eq!(dir.parent(), Some(data_dir.join("tracks").as_path()));
         }
     }
 }


### PR DESCRIPTION
## Summary

- Track ids received from the frontend over Tauri IPC are now parsed as UUIDs (`paths::parse_track_id`) at every command boundary — `delete_track`, `export_stems`, `get_stem_paths`, `update_track_meta`, `retry_track` — before any DB or filesystem access. A well-formed UUID can never contain `/`, `..`, or an absolute-path prefix, so this closes the traversal vector at the source.
- `db::delete_track` / `db::update_track_meta` now return the affected row count instead of discarding it, so `delete_track` treats "no row deleted" as `track not found` and skips the filesystem step entirely, instead of unconditionally calling `remove_dir_all`.
- `delete_track` also guards against a symlink planted at the track dir path — it unlinks the symlink itself rather than recursing through it.
- Local file import (`add_track_local`) now canonicalizes and validates the path in Rust (must exist, must be a regular file, must have an accepted audio extension) instead of relying only on the frontend's cosmetic extension check. The canonicalized path is what's stored as `source_path` and handed to ffmpeg, which also closes off protocol-like inputs (`http://...`) since canonicalization requires a real file to exist on disk.

Closes #98

## Test plan

- [x] `cargo test` — 70 tests pass, including new coverage for `../`, absolute paths, malformed UUIDs, missing records, and a symlink-escape scenario on delete
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `svelte-check` (ran via pre-commit hook, no frontend code changed)
- [ ] Manual smoke test in `just dev`: add a track via YouTube and local file, confirm it still plays/exports/deletes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVATVofq6pqgqq2WRzHDDP